### PR TITLE
Instantiate ontology cache in v2 endpoint

### DIFF
--- a/src/api/admin/groups/groups-endpoint.spec.ts
+++ b/src/api/admin/groups/groups-endpoint.spec.ts
@@ -1,4 +1,3 @@
-import { ApiResponseData, Group, UsersResponse } from "../../..";
 import { MockAjaxCall } from "../../../../test/mockajaxcall";
 import { KnoraApiConfig } from "../../../knora-api-config";
 import { KnoraApiConnection } from "../../../knora-api-connection";
@@ -6,8 +5,8 @@ import { CreateGroupRequest } from "../../../models/admin/create-group-request";
 import { GroupResponse } from "../../../models/admin/group-response";
 import { GroupsResponse } from "../../../models/admin/groups-response";
 import { MembersResponse } from "../../../models/admin/members-response";
-import { StoredGroup } from "../../../models/admin/stored-group";
 import { UpdateGroupRequest } from "../../../models/admin/update-group-request";
+import { ApiResponseData } from "../../../models/api-response-data";
 
 describe("GroupsEndpoint", () => {
 
@@ -55,7 +54,7 @@ describe("GroupsEndpoint", () => {
 
             const group = new CreateGroupRequest();
 
-            group.name =  "NewGroup";
+            group.name = "NewGroup";
             group.project = "http://rdfh.ch/projects/00FF";
             group.description = "NewGroupDescription";
             group.status = true;
@@ -124,7 +123,7 @@ describe("GroupsEndpoint", () => {
 
             const groupInfo = new UpdateGroupRequest();
 
-            groupInfo.name =  "UpdatedGroupName";
+            groupInfo.name = "UpdatedGroupName";
             groupInfo.description = "UpdatedGroupDescription";
 
             knoraApiConnection.admin.groupsEndpoint.updateGroup(groupIri, groupInfo).subscribe(

--- a/src/api/admin/permissions/permissions-endpoint.spec.ts
+++ b/src/api/admin/permissions/permissions-endpoint.spec.ts
@@ -1,4 +1,4 @@
-import { ApiResponseData, ApiResponseError, UsersResponse } from "../../..";
+import { ApiResponseData } from "../../../models/api-response-data";
 import { MockAjaxCall } from "../../../../test/mockajaxcall";
 import { KnoraApiConfig } from "../../../knora-api-config";
 import { KnoraApiConnection } from "../../../knora-api-connection";

--- a/src/api/admin/projects/projects-endpoint.spec.ts
+++ b/src/api/admin/projects/projects-endpoint.spec.ts
@@ -1,4 +1,5 @@
-import { ApiResponseData, Project } from "../../..";
+import { Project } from "../../../models/admin/project";
+import { ApiResponseData } from "../../../models/api-response-data";
 import { MockAjaxCall } from "../../../../test/mockajaxcall";
 import { KnoraApiConfig } from "../../../knora-api-config";
 import { KnoraApiConnection } from "../../../knora-api-connection";
@@ -7,7 +8,6 @@ import { MembersResponse } from "../../../models/admin/members-response";
 import { ProjectResponse } from "../../../models/admin/project-response";
 import { ProjectRestrictedViewSettingsResponse } from "../../../models/admin/project-restricted-view-settings-response";
 import { ProjectsResponse } from "../../../models/admin/projects-response";
-import { StoredProject } from "../../../models/admin/stored-project";
 import { StringLiteral } from "../../../models/admin/string-literal";
 import { UpdateProjectRequest } from "../../../models/admin/update-project-request";
 

--- a/src/api/admin/users/users-endpoint.spec.ts
+++ b/src/api/admin/users/users-endpoint.spec.ts
@@ -1,4 +1,6 @@
-import { ApiResponseError, User, UserResponse } from "../../..";
+import { User } from "../../../models/admin/user";
+import { ApiResponseError } from "../../../models/api-response-error";
+import { UserResponse } from "../../../models/admin/user-response";
 import { MockAjaxCall } from "../../../../test/mockajaxcall";
 import { KnoraApiConfig } from "../../../knora-api-config";
 import { KnoraApiConnection } from "../../../knora-api-connection";

--- a/src/api/v2/authentication/authentication-endpoint.spec.ts
+++ b/src/api/v2/authentication/authentication-endpoint.spec.ts
@@ -1,4 +1,7 @@
-import { ApiResponseData, ApiResponseError, LoginResponse, LogoutResponse } from "../../..";
+import { LogoutResponse } from  "../../../models/v2/authentication/logout-response";
+import { ApiResponseError } from "../../../models/api-response-error";
+import { LoginResponse } from "../../../models/v2/authentication/login-response";
+import { ApiResponseData } from "../../../models/api-response-data";
 import { MockAjaxCall } from "../../../../test/mockajaxcall";
 import { KnoraApiConfig } from "../../../knora-api-config";
 import { KnoraApiConnection } from "../../../knora-api-connection";

--- a/src/api/v2/list/lists-endpoint.ts
+++ b/src/api/v2/list/lists-endpoint.ts
@@ -1,9 +1,8 @@
 import { Observable } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import { catchError, map, mergeMap } from "rxjs/operators";
-import { ApiResponseError } from "../../..";
+import { ApiResponseError } from "../../../models/api-response-error";
 import { ListNode } from "../../../models/v2/lists/list-node";
-import { ReadOntology } from "../../../models/v2/ontologies/read-ontology";
 import { Endpoint } from "../../endpoint";
 
 declare let require: any; // http://stackoverflow.com/questions/34730010/angular2-5-minute-install-bug-require-is-not-defined

--- a/src/api/v2/ontology/ontologies-endpoint.ts
+++ b/src/api/v2/ontology/ontologies-endpoint.ts
@@ -1,7 +1,7 @@
 import { Observable } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import { catchError, map, mergeMap } from "rxjs/operators";
-import { ApiResponseError } from "../../..";
+import { ApiResponseError } from "../../../models/api-response-error";
 import { OntologyConversionUtil } from "../../../models/v2/ontologies/OntologyConversionUtil";
 import { ReadOntology } from "../../../models/v2/ontologies/read-ontology";
 import { Endpoint } from "../../endpoint";

--- a/src/api/v2/resource/resources-endpoint.spec.ts
+++ b/src/api/v2/resource/resources-endpoint.spec.ts
@@ -1,5 +1,4 @@
 import { of } from "rxjs";
-import { ListNodeCache } from "../../..";
 import { MockList } from "../../../../test/data/api/v2/mockList";
 import { MockOntology } from "../../../../test/data/api/v2/mockOntology";
 import { MockAjaxCall } from "../../../../test/mockajaxcall";
@@ -12,8 +11,6 @@ describe("ResourcesEndpoint", () => {
     const config = new KnoraApiConfig("http", "0.0.0.0", 3333, undefined, "", true);
     let knoraApiConnection: KnoraApiConnection;
 
-    let listNodeCache: ListNodeCache;
-
     let getResourceClassDefinitionFromCacheSpy: jasmine.Spy;
     let getListNodeFromCacheSpy: jasmine.Spy;
 
@@ -23,15 +20,13 @@ describe("ResourcesEndpoint", () => {
 
         knoraApiConnection = new KnoraApiConnection(config);
 
-        listNodeCache = new ListNodeCache(knoraApiConnection);
-
         getResourceClassDefinitionFromCacheSpy = spyOn(knoraApiConnection.v2.ontologyCache, "getResourceClassDefinition").and.callFake(
             (resClassIri: string) => {
                 return of(MockOntology.mockIResourceClassAndPropertyDefinitions(resClassIri));
             }
         );
 
-        getListNodeFromCacheSpy = spyOn(listNodeCache, "getNode").and.callFake(
+        getListNodeFromCacheSpy = spyOn(knoraApiConnection.v2.listNodeCache, "getNode").and.callFake(
             (listNodeIri: string) => {
                 return MockList.mockCompletedAsyncSubject(listNodeIri);
             }
@@ -44,7 +39,7 @@ describe("ResourcesEndpoint", () => {
 
     it("should return a resource", done => {
 
-        knoraApiConnection.v2.res.getResource("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw", listNodeCache).subscribe((response: ReadResource) => {
+        knoraApiConnection.v2.res.getResource("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw").subscribe((response: ReadResource) => {
 
             expect(response.id).toEqual("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw");
             expect(response.resourceClassLabel).toEqual("Thing");
@@ -69,7 +64,7 @@ describe("ResourcesEndpoint", () => {
 
     it("should return several resource", done => {
 
-        knoraApiConnection.v2.res.getResources(["http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw", "http://rdfh.ch/0001/uqmMo72OQ2K2xe7mkIytlg"], listNodeCache).subscribe((response: ReadResource[]) => {
+        knoraApiConnection.v2.res.getResources(["http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw", "http://rdfh.ch/0001/uqmMo72OQ2K2xe7mkIytlg"]).subscribe((response: ReadResource[]) => {
 
             expect(response.length).toEqual(2);
 

--- a/src/api/v2/resource/resources-endpoint.spec.ts
+++ b/src/api/v2/resource/resources-endpoint.spec.ts
@@ -1,11 +1,10 @@
-import { AsyncSubject, of } from "rxjs";
-import { ListNodeCache, OntologyCache } from "../../..";
+import { of } from "rxjs";
+import { ListNodeCache } from "../../..";
 import { MockList } from "../../../../test/data/api/v2/mockList";
 import { MockOntology } from "../../../../test/data/api/v2/mockOntology";
 import { MockAjaxCall } from "../../../../test/mockajaxcall";
 import { KnoraApiConfig } from "../../../knora-api-config";
 import { KnoraApiConnection } from "../../../knora-api-connection";
-import { ListNode } from "../../../models/v2/lists/list-node";
 import { ReadResource } from "../../../models/v2/resources/read-resource";
 
 describe("ResourcesEndpoint", () => {
@@ -88,7 +87,5 @@ describe("ResourcesEndpoint", () => {
         expect(request.method).toEqual("GET");
 
     });
-
-
 
 });

--- a/src/api/v2/resource/resources-endpoint.spec.ts
+++ b/src/api/v2/resource/resources-endpoint.spec.ts
@@ -11,10 +11,9 @@ import { ReadResource } from "../../../models/v2/resources/read-resource";
 describe("ResourcesEndpoint", () => {
 
     const config = new KnoraApiConfig("http", "0.0.0.0", 3333, undefined, "", true);
-    const knoraApiConnection = new KnoraApiConnection(config);
+    let knoraApiConnection: KnoraApiConnection;
 
-    const ontoCache = new OntologyCache(knoraApiConnection, config);
-    const listNodeCache = new ListNodeCache(knoraApiConnection);
+    let listNodeCache: ListNodeCache;
 
     let getResourceClassDefinitionFromCacheSpy: jasmine.Spy;
     let getListNodeFromCacheSpy: jasmine.Spy;
@@ -23,7 +22,11 @@ describe("ResourcesEndpoint", () => {
 
         jasmine.Ajax.install();
 
-        getResourceClassDefinitionFromCacheSpy = spyOn(ontoCache, "getResourceClassDefinition").and.callFake(
+        knoraApiConnection = new KnoraApiConnection(config);
+
+        listNodeCache = new ListNodeCache(knoraApiConnection);
+
+        getResourceClassDefinitionFromCacheSpy = spyOn(knoraApiConnection.v2.ontologyCache, "getResourceClassDefinition").and.callFake(
             (resClassIri: string) => {
                 return of(MockOntology.mockIResourceClassAndPropertyDefinitions(resClassIri));
             }
@@ -42,7 +45,7 @@ describe("ResourcesEndpoint", () => {
 
     it("should return a resource", done => {
 
-        knoraApiConnection.v2.res.getResource("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw", ontoCache, listNodeCache).subscribe((response: ReadResource) => {
+        knoraApiConnection.v2.res.getResource("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw", listNodeCache).subscribe((response: ReadResource) => {
 
             expect(response.id).toEqual("http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw");
             expect(response.resourceClassLabel).toEqual("Thing");
@@ -67,7 +70,7 @@ describe("ResourcesEndpoint", () => {
 
     it("should return several resource", done => {
 
-        knoraApiConnection.v2.res.getResources(["http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw", "http://rdfh.ch/0001/uqmMo72OQ2K2xe7mkIytlg"], ontoCache, listNodeCache).subscribe((response: ReadResource[]) => {
+        knoraApiConnection.v2.res.getResources(["http://rdfh.ch/0001/H6gBWUuJSuuO-CilHV8kQw", "http://rdfh.ch/0001/uqmMo72OQ2K2xe7mkIytlg"], listNodeCache).subscribe((response: ReadResource[]) => {
 
             expect(response.length).toEqual(2);
 

--- a/src/api/v2/resource/resources-endpoint.ts
+++ b/src/api/v2/resource/resources-endpoint.ts
@@ -1,7 +1,7 @@
 import { Observable } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import { catchError, map, mergeMap } from "rxjs/operators";
-import { ApiResponseError, KnoraApiConfig, ListNodeCache } from "../../..";
+import { ApiResponseError, KnoraApiConfig } from "../../..";
 import { ReadResource } from "../../../models/v2/resources/read-resource";
 import { ResourcesConversionUtil } from "../../../models/v2/resources/ResourcesConversionUtil";
 import { Endpoint } from "../../endpoint";
@@ -25,7 +25,7 @@ export class ResourcesEndpoint extends Endpoint {
      * @param resourceIris Iris of the resources to get.
      * @param listNodeCache instance of `ListNodeCache` to be used.
      */
-    getResources(resourceIris: string[], listNodeCache: ListNodeCache): Observable<ReadResource[] | ApiResponseError> {
+    getResources(resourceIris: string[]): Observable<ReadResource[] | ApiResponseError> {
         // TODO: Do not hard-code the URL and http call params, generate this from Knora
 
         // make URL containing resource Iris as segments
@@ -43,7 +43,7 @@ export class ResourcesEndpoint extends Endpoint {
                 return jsonld.compact(ajaxResponse.response, {});
             }), mergeMap((jsonldobj: object) => {
                 // console.log(JSON.stringify(jsonldobj));
-                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, listNodeCache, this.jsonConvert);
+                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, this.v2Endpoint.listNodeCache, this.jsonConvert);
             }),
             catchError(error => {
                 return this.handleError(error);
@@ -57,8 +57,8 @@ export class ResourcesEndpoint extends Endpoint {
      * @param resourceIri Iri of the resource to get.
      * @param listNodeCache instance of `ListNodeCache` to use.
      */
-    getResource(resourceIri: string, listNodeCache: ListNodeCache): Observable<ReadResource | ApiResponseError> {
-        return this.getResources([resourceIri], listNodeCache).pipe(
+    getResource(resourceIri: string): Observable<ReadResource | ApiResponseError> {
+        return this.getResources([resourceIri]).pipe(
             map((resources: ReadResource[]) => resources[0]),
             catchError(error => {
                 return this.handleError(error);

--- a/src/api/v2/resource/resources-endpoint.ts
+++ b/src/api/v2/resource/resources-endpoint.ts
@@ -1,7 +1,8 @@
 import { Observable } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import { catchError, map, mergeMap } from "rxjs/operators";
-import { ApiResponseError, KnoraApiConfig } from "../../..";
+import { ApiResponseError } from "../../../models/api-response-error";
+import { KnoraApiConfig } from "../../../knora-api-config";
 import { ReadResource } from "../../../models/v2/resources/read-resource";
 import { ResourcesConversionUtil } from "../../../models/v2/resources/ResourcesConversionUtil";
 import { Endpoint } from "../../endpoint";

--- a/src/api/v2/resource/resources-endpoint.ts
+++ b/src/api/v2/resource/resources-endpoint.ts
@@ -1,10 +1,11 @@
 import { Observable } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import { catchError, map, mergeMap } from "rxjs/operators";
-import { ApiResponseError, ListNodeCache, OntologyCache } from "../../..";
+import { ApiResponseError, KnoraApiConfig, ListNodeCache, OntologyCache } from "../../..";
 import { ReadResource } from "../../../models/v2/resources/read-resource";
 import { ResourcesConversionUtil } from "../../../models/v2/resources/ResourcesConversionUtil";
 import { Endpoint } from "../../endpoint";
+import { V2Endpoint } from "../v2-endpoint";
 
 declare let require: any; // http://stackoverflow.com/questions/34730010/angular2-5-minute-install-bug-require-is-not-defined
 const jsonld = require("jsonld/dist/jsonld.js");
@@ -14,14 +15,17 @@ const jsonld = require("jsonld/dist/jsonld.js");
  */
 export class ResourcesEndpoint extends Endpoint {
 
+    constructor(protected readonly knoraApiConfig: KnoraApiConfig, protected readonly path: string, private readonly v2Endpoint: V2Endpoint) {
+        super(knoraApiConfig, path);
+    }
+
     /**
      * Given a sequence of resource IRIs, gets the resources from Knora.
      *
      * @param resourceIris Iris of the resources to get.
-     * @param ontologyCache instance of `OntologyCache` to be used.
      * @param listNodeCache instance of `ListNodeCache` to be used.
      */
-    getResources(resourceIris: string[], ontologyCache: OntologyCache, listNodeCache: ListNodeCache): Observable<ReadResource[] | ApiResponseError> {
+    getResources(resourceIris: string[], listNodeCache: ListNodeCache): Observable<ReadResource[] | ApiResponseError> {
         // TODO: Do not hard-code the URL and http call params, generate this from Knora
 
         // make URL containing resource Iris as segments
@@ -39,7 +43,7 @@ export class ResourcesEndpoint extends Endpoint {
                 return jsonld.compact(ajaxResponse.response, {});
             }), mergeMap((jsonldobj: object) => {
                 // console.log(JSON.stringify(jsonldobj));
-                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, ontologyCache, listNodeCache, this.jsonConvert);
+                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, listNodeCache, this.jsonConvert);
             }),
             catchError(error => {
                 return this.handleError(error);
@@ -51,11 +55,10 @@ export class ResourcesEndpoint extends Endpoint {
      * Given a resource IRI, gets the resource from Knora.
      *
      * @param resourceIri Iri of the resource to get.
-     * @param ontologyCache instance of `OntologyCache` to use.
      * @param listNodeCache instance of `ListNodeCache` to use.
      */
-    getResource(resourceIri: string, ontologyCache: OntologyCache, listNodeCache: ListNodeCache): Observable<ReadResource | ApiResponseError> {
-        return this.getResources([resourceIri], ontologyCache, listNodeCache).pipe(
+    getResource(resourceIri: string, listNodeCache: ListNodeCache): Observable<ReadResource | ApiResponseError> {
+        return this.getResources([resourceIri], listNodeCache).pipe(
             map((resources: ReadResource[]) => resources[0]),
             catchError(error => {
                 return this.handleError(error);

--- a/src/api/v2/resource/resources-endpoint.ts
+++ b/src/api/v2/resource/resources-endpoint.ts
@@ -1,7 +1,7 @@
 import { Observable } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import { catchError, map, mergeMap } from "rxjs/operators";
-import { ApiResponseError, KnoraApiConfig, ListNodeCache, OntologyCache } from "../../..";
+import { ApiResponseError, KnoraApiConfig, ListNodeCache } from "../../..";
 import { ReadResource } from "../../../models/v2/resources/read-resource";
 import { ResourcesConversionUtil } from "../../../models/v2/resources/ResourcesConversionUtil";
 import { Endpoint } from "../../endpoint";

--- a/src/api/v2/resource/resources-endpoint.ts
+++ b/src/api/v2/resource/resources-endpoint.ts
@@ -24,7 +24,6 @@ export class ResourcesEndpoint extends Endpoint {
      * Given a sequence of resource IRIs, gets the resources from Knora.
      *
      * @param resourceIris Iris of the resources to get.
-     * @param listNodeCache instance of `ListNodeCache` to be used.
      */
     getResources(resourceIris: string[]): Observable<ReadResource[] | ApiResponseError> {
         // TODO: Do not hard-code the URL and http call params, generate this from Knora
@@ -56,7 +55,6 @@ export class ResourcesEndpoint extends Endpoint {
      * Given a resource IRI, gets the resource from Knora.
      *
      * @param resourceIri Iri of the resource to get.
-     * @param listNodeCache instance of `ListNodeCache` to use.
      */
     getResource(resourceIri: string): Observable<ReadResource | ApiResponseError> {
         return this.getResources([resourceIri]).pipe(

--- a/src/api/v2/search/search-endpoint.spec.ts
+++ b/src/api/v2/search/search-endpoint.spec.ts
@@ -1,5 +1,4 @@
 import { of } from "rxjs";
-import { ListNodeCache } from "../../..";
 import { MockList } from "../../../../test/data/api/v2/mockList";
 import { MockOntology } from "../../../../test/data/api/v2/mockOntology";
 import { MockAjaxCall } from "../../../../test/mockajaxcall";
@@ -14,8 +13,6 @@ describe("SearchEndpoint", () => {
     const config = new KnoraApiConfig("http", "0.0.0.0", 3333, undefined, "", true);
     let knoraApiConnection: KnoraApiConnection;
 
-    let listNodeCache: ListNodeCache;
-
     let getResourceClassSpy: jasmine.Spy;
 
     let getListNodeFromCacheSpy: jasmine.Spy;
@@ -25,8 +22,6 @@ describe("SearchEndpoint", () => {
 
         knoraApiConnection = new KnoraApiConnection(config);
 
-        listNodeCache = new ListNodeCache(knoraApiConnection);
-
         getResourceClassSpy = spyOn(knoraApiConnection.v2.ontologyCache, "getResourceClassDefinition").and.callFake(
             (resClassIri: string) => {
 
@@ -34,7 +29,7 @@ describe("SearchEndpoint", () => {
             }
         );
 
-        getListNodeFromCacheSpy = spyOn(listNodeCache, "getNode").and.callFake(
+        getListNodeFromCacheSpy = spyOn(knoraApiConnection.v2.listNodeCache, "getNode").and.callFake(
             (listNodeIri: string) => {
                 return MockList.mockCompletedAsyncSubject(listNodeIri);
             }
@@ -79,7 +74,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a fulltext search with a simple search term", done => {
 
-            knoraApiConnection.v2.search.doFulltextSearch("thing", listNodeCache, 0).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doFulltextSearch("thing", 0).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -100,7 +95,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a fulltext search with a simple search term using offset 1", done => {
 
-            knoraApiConnection.v2.search.doFulltextSearch("thing", listNodeCache, 1).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doFulltextSearch("thing", 1).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -121,7 +116,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a fulltext search with a simple search term restricting the search to a specific resource class", done => {
 
-            knoraApiConnection.v2.search.doFulltextSearch("thing", listNodeCache, 1, {limitToResourceClass: "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"}).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doFulltextSearch("thing", 1, {limitToResourceClass: "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"}).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -143,7 +138,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a fulltext search with a simple search term restricting the search to a specific project", done => {
 
-            knoraApiConnection.v2.search.doFulltextSearch("thing", listNodeCache, 1, {limitToProject: "http://rdfh.ch/projects/0001"}).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doFulltextSearch("thing", 1, {limitToProject: "http://rdfh.ch/projects/0001"}).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -165,7 +160,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a fulltext search with a simple search term restricting the search to a specific standoff class", done => {
 
-            knoraApiConnection.v2.search.doFulltextSearch("thing", listNodeCache, 1, {limitToStandoffClass: "http://api.knora.org/ontology/standoff/v2#StandoffParagraphTag"}).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doFulltextSearch("thing", 1, {limitToStandoffClass: "http://api.knora.org/ontology/standoff/v2#StandoffParagraphTag"}).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -228,7 +223,7 @@ describe("SearchEndpoint", () => {
                 OFFSET 0
             `;
 
-            knoraApiConnection.v2.search.doExtendedSearch(gravsearchQuery, listNodeCache).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doExtendedSearch(gravsearchQuery).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -318,7 +313,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a label search with a simple search term", done => {
 
-            knoraApiConnection.v2.search.doSearchByLabel("thing", listNodeCache, 0).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doSearchByLabel("thing", 0).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -339,7 +334,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a label search with a simple search term using offset 1", done => {
 
-            knoraApiConnection.v2.search.doSearchByLabel("thing", listNodeCache, 1).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doSearchByLabel("thing", 1).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -360,7 +355,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a label search with a simple search term restricting the search to a specific resource class", done => {
 
-            knoraApiConnection.v2.search.doSearchByLabel("thing", listNodeCache, 1, {limitToResourceClass: "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"}).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doSearchByLabel("thing", 1, {limitToResourceClass: "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"}).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -382,7 +377,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a label search with a simple search term restricting the search to a specific project", done => {
 
-            knoraApiConnection.v2.search.doSearchByLabel("thing", listNodeCache, 1, {limitToProject: "http://rdfh.ch/projects/0001"}).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doSearchByLabel("thing", 1, {limitToProject: "http://rdfh.ch/projects/0001"}).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 

--- a/src/api/v2/search/search-endpoint.spec.ts
+++ b/src/api/v2/search/search-endpoint.spec.ts
@@ -13,10 +13,9 @@ import { SearchEndpoint } from "./search-endpoint";
 describe("SearchEndpoint", () => {
 
     const config = new KnoraApiConfig("http", "0.0.0.0", 3333, undefined, "", true);
-    const knoraApiConnection = new KnoraApiConnection(config);
+    let knoraApiConnection: KnoraApiConnection;
 
-    const ontoCache = new OntologyCache(knoraApiConnection, config);
-    const listNodeCache = new ListNodeCache(knoraApiConnection);
+    let listNodeCache: ListNodeCache;
 
     let getResourceClassSpy: jasmine.Spy;
 
@@ -25,7 +24,11 @@ describe("SearchEndpoint", () => {
     beforeEach(() => {
         jasmine.Ajax.install();
 
-        getResourceClassSpy = spyOn(ontoCache, "getResourceClassDefinition").and.callFake(
+        knoraApiConnection = new KnoraApiConnection(config);
+
+        listNodeCache = new ListNodeCache(knoraApiConnection);
+
+        getResourceClassSpy = spyOn(knoraApiConnection.v2.ontologyCache, "getResourceClassDefinition").and.callFake(
             (resClassIri: string) => {
 
                 return of(MockOntology.mockIResourceClassAndPropertyDefinitions(resClassIri));
@@ -77,7 +80,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a fulltext search with a simple search term", done => {
 
-            knoraApiConnection.v2.search.doFulltextSearch("thing", ontoCache, listNodeCache, 0).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doFulltextSearch("thing", listNodeCache, 0).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -98,7 +101,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a fulltext search with a simple search term using offset 1", done => {
 
-            knoraApiConnection.v2.search.doFulltextSearch("thing", ontoCache, listNodeCache, 1).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doFulltextSearch("thing", listNodeCache, 1).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -119,7 +122,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a fulltext search with a simple search term restricting the search to a specific resource class", done => {
 
-            knoraApiConnection.v2.search.doFulltextSearch("thing", ontoCache, listNodeCache, 1, {limitToResourceClass: "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"}).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doFulltextSearch("thing", listNodeCache, 1, {limitToResourceClass: "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"}).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -141,7 +144,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a fulltext search with a simple search term restricting the search to a specific project", done => {
 
-            knoraApiConnection.v2.search.doFulltextSearch("thing", ontoCache, listNodeCache, 1, {limitToProject: "http://rdfh.ch/projects/0001"}).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doFulltextSearch("thing", listNodeCache, 1, {limitToProject: "http://rdfh.ch/projects/0001"}).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -163,7 +166,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a fulltext search with a simple search term restricting the search to a specific standoff class", done => {
 
-            knoraApiConnection.v2.search.doFulltextSearch("thing", ontoCache, listNodeCache, 1, {limitToStandoffClass: "http://api.knora.org/ontology/standoff/v2#StandoffParagraphTag"}).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doFulltextSearch("thing", listNodeCache, 1, {limitToStandoffClass: "http://api.knora.org/ontology/standoff/v2#StandoffParagraphTag"}).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -226,7 +229,7 @@ describe("SearchEndpoint", () => {
                 OFFSET 0
             `;
 
-            knoraApiConnection.v2.search.doExtendedSearch(gravsearchQuery, ontoCache, listNodeCache).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doExtendedSearch(gravsearchQuery, listNodeCache).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -316,7 +319,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a label search with a simple search term", done => {
 
-            knoraApiConnection.v2.search.doSearchByLabel("thing", ontoCache, listNodeCache, 0).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doSearchByLabel("thing", listNodeCache, 0).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -337,7 +340,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a label search with a simple search term using offset 1", done => {
 
-            knoraApiConnection.v2.search.doSearchByLabel("thing", ontoCache, listNodeCache, 1).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doSearchByLabel("thing", listNodeCache, 1).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -358,7 +361,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a label search with a simple search term restricting the search to a specific resource class", done => {
 
-            knoraApiConnection.v2.search.doSearchByLabel("thing", ontoCache, listNodeCache, 1, {limitToResourceClass: "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"}).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doSearchByLabel("thing", listNodeCache, 1, {limitToResourceClass: "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"}).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 
@@ -380,7 +383,7 @@ describe("SearchEndpoint", () => {
 
         it("should do a label search with a simple search term restricting the search to a specific project", done => {
 
-            knoraApiConnection.v2.search.doSearchByLabel("thing", ontoCache, listNodeCache, 1, {limitToProject: "http://rdfh.ch/projects/0001"}).subscribe((response: ReadResource[]) => {
+            knoraApiConnection.v2.search.doSearchByLabel("thing", listNodeCache, 1, {limitToProject: "http://rdfh.ch/projects/0001"}).subscribe((response: ReadResource[]) => {
 
                 expect(response.length).toEqual(2);
 

--- a/src/api/v2/search/search-endpoint.spec.ts
+++ b/src/api/v2/search/search-endpoint.spec.ts
@@ -1,11 +1,10 @@
-import { AsyncSubject, of } from "rxjs";
-import { ListNodeCache, OntologyCache } from "../../..";
+import { of } from "rxjs";
+import { ListNodeCache } from "../../..";
 import { MockList } from "../../../../test/data/api/v2/mockList";
 import { MockOntology } from "../../../../test/data/api/v2/mockOntology";
 import { MockAjaxCall } from "../../../../test/mockajaxcall";
 import { KnoraApiConfig } from "../../../knora-api-config";
 import { KnoraApiConnection } from "../../../knora-api-connection";
-import { ListNode } from "../../../models/v2/lists/list-node";
 import { ReadResource } from "../../../models/v2/resources/read-resource";
 import { CountQueryResponse } from "../../../models/v2/search/count-query-response";
 import { SearchEndpoint } from "./search-endpoint";

--- a/src/api/v2/search/search-endpoint.ts
+++ b/src/api/v2/search/search-endpoint.ts
@@ -1,7 +1,7 @@
 import { Observable } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import { catchError, map, mergeMap } from "rxjs/operators";
-import { ApiResponseError, KnoraApiConfig, ListNodeCache } from "../../..";
+import { ApiResponseError, KnoraApiConfig } from "../../..";
 import { ReadResource } from "../../../models/v2/resources/read-resource";
 import { ResourcesConversionUtil } from "../../../models/v2/resources/ResourcesConversionUtil";
 import { CountQueryResponse } from "../../../models/v2/search/count-query-response";
@@ -122,7 +122,7 @@ export class SearchEndpoint extends Endpoint {
      * @param offset offset to be used for paging, zero-based.
      * @param params parameters for fulltext search, if any.
      */
-    doFulltextSearch(searchTerm: string, listNodeCache: ListNodeCache, offset = 0, params?: IFulltextSearchParams): Observable<ReadResource[] | ApiResponseError> {
+    doFulltextSearch(searchTerm: string, offset = 0, params?: IFulltextSearchParams): Observable<ReadResource[] | ApiResponseError> {
         // TODO: Do not hard-code the URL and http call params, generate this from Knora
 
         return this.httpGet("/search/" + encodeURIComponent(searchTerm) + SearchEndpoint.encodeFulltextParams(offset, params)).pipe(
@@ -133,7 +133,7 @@ export class SearchEndpoint extends Endpoint {
                 return jsonld.compact(ajaxResponse.response, {});
             }), mergeMap((jsonldobj: object) => {
                 // console.log(JSON.stringify(jsonldobj));
-                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, listNodeCache, this.jsonConvert);
+                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, this.v2Endpoint.listNodeCache, this.jsonConvert);
             }),
             catchError(error => {
                 return this.handleError(error);
@@ -173,7 +173,7 @@ export class SearchEndpoint extends Endpoint {
      * @param gravsearchQuery the given Gravsearch query.
      * @param listNodeCache instance of `ListNodeCache` to be used.
      */
-    doExtendedSearch(gravsearchQuery: string, listNodeCache: ListNodeCache): Observable<ReadResource[] | ApiResponseError> {
+    doExtendedSearch(gravsearchQuery: string): Observable<ReadResource[] | ApiResponseError> {
         // TODO: Do not hard-code the URL and http call params, generate this from Knora
 
         // TODO: check if content-type have to be set to text/plain
@@ -186,7 +186,7 @@ export class SearchEndpoint extends Endpoint {
                 return jsonld.compact(ajaxResponse.response, {});
             }), mergeMap((jsonldobj: object) => {
                 // console.log(JSON.stringify(jsonldobj));
-                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, listNodeCache, this.jsonConvert);
+                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, this.v2Endpoint.listNodeCache, this.jsonConvert);
             }),
             catchError(error => {
                 return this.handleError(error);
@@ -226,7 +226,7 @@ export class SearchEndpoint extends Endpoint {
      * @param offset offset to be used for paging, zero-based.
      * @param params parameters for fulltext search, if any.
      */
-    doSearchByLabel(searchTerm: string, listNodeCache: ListNodeCache, offset = 0, params?: ILabelSearchParams): Observable<ReadResource[] | ApiResponseError> {
+    doSearchByLabel(searchTerm: string, offset = 0, params?: ILabelSearchParams): Observable<ReadResource[] | ApiResponseError> {
         // TODO: Do not hard-code the URL and http call params, generate this from Knora
 
         return this.httpGet("/searchbylabel/" + encodeURIComponent(searchTerm) + SearchEndpoint.encodeLabelParams(offset, params)).pipe(
@@ -237,7 +237,7 @@ export class SearchEndpoint extends Endpoint {
                 return jsonld.compact(ajaxResponse.response, {});
             }), mergeMap((jsonldobj: object) => {
                 // console.log(JSON.stringify(jsonldobj));
-                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, listNodeCache, this.jsonConvert);
+                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, this.v2Endpoint.listNodeCache, this.jsonConvert);
             }),
             catchError(error => {
                 return this.handleError(error);

--- a/src/api/v2/search/search-endpoint.ts
+++ b/src/api/v2/search/search-endpoint.ts
@@ -1,11 +1,12 @@
 import { Observable } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import { catchError, map, mergeMap } from "rxjs/operators";
-import { ApiResponseError, ListNodeCache, OntologyCache } from "../../..";
+import { ApiResponseError, KnoraApiConfig, ListNodeCache } from "../../..";
 import { ReadResource } from "../../../models/v2/resources/read-resource";
 import { ResourcesConversionUtil } from "../../../models/v2/resources/ResourcesConversionUtil";
 import { CountQueryResponse } from "../../../models/v2/search/count-query-response";
 import { Endpoint } from "../../endpoint";
+import { V2Endpoint } from "../v2-endpoint";
 
 declare let require: any; // http://stackoverflow.com/questions/34730010/angular2-5-minute-install-bug-require-is-not-defined
 const jsonld = require("jsonld/dist/jsonld.js");
@@ -53,6 +54,10 @@ export interface ILabelSearchParams {
  * Handles requests to the search route of the Knora API.
  */
 export class SearchEndpoint extends Endpoint {
+
+    constructor(protected readonly knoraApiConfig: KnoraApiConfig, protected readonly path: string, private readonly v2Endpoint: V2Endpoint) {
+        super(knoraApiConfig, path);
+    }
 
     /**
      * URL encodes fulltext search params.
@@ -113,12 +118,11 @@ export class SearchEndpoint extends Endpoint {
      * Performs a fulltext search.
      *
      * @param searchTerm the term to search for.
-     * @param ontologyCache instance of `OntologyCache` to be used.
      * @param listNodeCache instance of `ListNodeCache` to be used.
      * @param offset offset to be used for paging, zero-based.
      * @param params parameters for fulltext search, if any.
      */
-    doFulltextSearch(searchTerm: string, ontologyCache: OntologyCache, listNodeCache: ListNodeCache, offset = 0, params?: IFulltextSearchParams): Observable<ReadResource[] | ApiResponseError> {
+    doFulltextSearch(searchTerm: string, listNodeCache: ListNodeCache, offset = 0, params?: IFulltextSearchParams): Observable<ReadResource[] | ApiResponseError> {
         // TODO: Do not hard-code the URL and http call params, generate this from Knora
 
         return this.httpGet("/search/" + encodeURIComponent(searchTerm) + SearchEndpoint.encodeFulltextParams(offset, params)).pipe(
@@ -129,7 +133,7 @@ export class SearchEndpoint extends Endpoint {
                 return jsonld.compact(ajaxResponse.response, {});
             }), mergeMap((jsonldobj: object) => {
                 // console.log(JSON.stringify(jsonldobj));
-                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, ontologyCache, listNodeCache, this.jsonConvert);
+                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, listNodeCache, this.jsonConvert);
             }),
             catchError(error => {
                 return this.handleError(error);
@@ -167,10 +171,9 @@ export class SearchEndpoint extends Endpoint {
      * Performs a Gravsearch query.
      *
      * @param gravsearchQuery the given Gravsearch query.
-     * @param ontologyCache instance of `OntologyCache` to be used.
      * @param listNodeCache instance of `ListNodeCache` to be used.
      */
-    doExtendedSearch(gravsearchQuery: string, ontologyCache: OntologyCache, listNodeCache: ListNodeCache): Observable<ReadResource[] | ApiResponseError> {
+    doExtendedSearch(gravsearchQuery: string, listNodeCache: ListNodeCache): Observable<ReadResource[] | ApiResponseError> {
         // TODO: Do not hard-code the URL and http call params, generate this from Knora
 
         // TODO: check if content-type have to be set to text/plain
@@ -183,7 +186,7 @@ export class SearchEndpoint extends Endpoint {
                 return jsonld.compact(ajaxResponse.response, {});
             }), mergeMap((jsonldobj: object) => {
                 // console.log(JSON.stringify(jsonldobj));
-                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, ontologyCache, listNodeCache, this.jsonConvert);
+                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, listNodeCache, this.jsonConvert);
             }),
             catchError(error => {
                 return this.handleError(error);
@@ -219,12 +222,11 @@ export class SearchEndpoint extends Endpoint {
      * Performs a search by label.
      *
      * @param searchTerm the label to search for.
-     * @param ontologyCache instance of `OntologyCache` to be used.
      * @param listNodeCache instance of `ListNodeCache` to be used.
      * @param offset offset to be used for paging, zero-based.
      * @param params parameters for fulltext search, if any.
      */
-    doSearchByLabel(searchTerm: string, ontologyCache: OntologyCache, listNodeCache: ListNodeCache, offset = 0, params?: ILabelSearchParams): Observable<ReadResource[] | ApiResponseError> {
+    doSearchByLabel(searchTerm: string, listNodeCache: ListNodeCache, offset = 0, params?: ILabelSearchParams): Observable<ReadResource[] | ApiResponseError> {
         // TODO: Do not hard-code the URL and http call params, generate this from Knora
 
         return this.httpGet("/searchbylabel/" + encodeURIComponent(searchTerm) + SearchEndpoint.encodeLabelParams(offset, params)).pipe(
@@ -235,7 +237,7 @@ export class SearchEndpoint extends Endpoint {
                 return jsonld.compact(ajaxResponse.response, {});
             }), mergeMap((jsonldobj: object) => {
                 // console.log(JSON.stringify(jsonldobj));
-                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, ontologyCache, listNodeCache, this.jsonConvert);
+                return ResourcesConversionUtil.createReadResourceSequence(jsonldobj, this.v2Endpoint.ontologyCache, listNodeCache, this.jsonConvert);
             }),
             catchError(error => {
                 return this.handleError(error);

--- a/src/api/v2/search/search-endpoint.ts
+++ b/src/api/v2/search/search-endpoint.ts
@@ -1,7 +1,8 @@
 import { Observable } from "rxjs";
 import { AjaxResponse } from "rxjs/ajax";
 import { catchError, map, mergeMap } from "rxjs/operators";
-import { ApiResponseError, KnoraApiConfig } from "../../..";
+import { KnoraApiConfig } from "../../../knora-api-config";
+import { ApiResponseError } from "../../../models/api-response-error";
 import { ReadResource } from "../../../models/v2/resources/read-resource";
 import { ResourcesConversionUtil } from "../../../models/v2/resources/ResourcesConversionUtil";
 import { CountQueryResponse } from "../../../models/v2/search/count-query-response";
@@ -118,7 +119,6 @@ export class SearchEndpoint extends Endpoint {
      * Performs a fulltext search.
      *
      * @param searchTerm the term to search for.
-     * @param listNodeCache instance of `ListNodeCache` to be used.
      * @param offset offset to be used for paging, zero-based.
      * @param params parameters for fulltext search, if any.
      */
@@ -171,7 +171,6 @@ export class SearchEndpoint extends Endpoint {
      * Performs a Gravsearch query.
      *
      * @param gravsearchQuery the given Gravsearch query.
-     * @param listNodeCache instance of `ListNodeCache` to be used.
      */
     doExtendedSearch(gravsearchQuery: string): Observable<ReadResource[] | ApiResponseError> {
         // TODO: Do not hard-code the URL and http call params, generate this from Knora
@@ -222,7 +221,6 @@ export class SearchEndpoint extends Endpoint {
      * Performs a search by label.
      *
      * @param searchTerm the label to search for.
-     * @param listNodeCache instance of `ListNodeCache` to be used.
      * @param offset offset to be used for paging, zero-based.
      * @param params parameters for fulltext search, if any.
      */

--- a/src/api/v2/v2-endpoint.ts
+++ b/src/api/v2/v2-endpoint.ts
@@ -1,3 +1,4 @@
+import { ListNodeCache } from "../../cache/ListNodeCache";
 import { OntologyCache } from "../../cache/OntologyCache";
 import { KnoraApiConfig } from "../../knora-api-config";
 import { Endpoint } from "../endpoint";
@@ -30,6 +31,8 @@ export class V2Endpoint extends Endpoint {
 
     readonly ontologyCache: OntologyCache;
 
+    readonly listNodeCache: ListNodeCache;
+
     /**
      * Constructor.
      * Sets up all endpoints for this endpoint.
@@ -49,6 +52,7 @@ export class V2Endpoint extends Endpoint {
 
         // Instantiate caches
         this.ontologyCache = new OntologyCache(knoraApiConfig, this);
+        this.listNodeCache = new ListNodeCache(this);
     }
 
 }

--- a/src/api/v2/v2-endpoint.ts
+++ b/src/api/v2/v2-endpoint.ts
@@ -1,3 +1,4 @@
+import { OntologyCache } from "../..";
 import { KnoraApiConfig } from "../../knora-api-config";
 import { Endpoint } from "../endpoint";
 import { AuthenticationEndpoint } from "./authentication/authentication-endpoint";
@@ -11,35 +12,13 @@ import { SearchEndpoint } from "./search/search-endpoint";
  */
 export class V2Endpoint extends Endpoint {
 
-    ///////////////
-    // CONSTANTS //
-    ///////////////
-
-    // <editor-fold desc="">
-
     static readonly PATH_AUTHENTICATION = "/authentication";
 
     static readonly PATH_ONTOLOGIES = "/ontologies";
 
     static readonly PATH_RESOURCES = "/resources";
 
-    // </editor-fold>
-
-    ////////////////
-    // PROPERTIES //
-    ////////////////
-
-    // <editor-fold desc="">
-
     readonly auth: AuthenticationEndpoint;
-
-    // </editor-fold>
-
-    /////////////////
-    // CONSTRUCTOR //
-    /////////////////
-
-    // <editor-fold desc="">
 
     readonly onto: OntologiesEndpoint;
 
@@ -48,6 +27,8 @@ export class V2Endpoint extends Endpoint {
     readonly list: ListsEndpoint;
 
     readonly search: SearchEndpoint;
+
+    readonly ontologyCache: OntologyCache;
 
     /**
      * Constructor.
@@ -62,19 +43,12 @@ export class V2Endpoint extends Endpoint {
         // Instantiate the endpoints
         this.auth = new AuthenticationEndpoint(knoraApiConfig, path + V2Endpoint.PATH_AUTHENTICATION);
         this.onto = new OntologiesEndpoint(knoraApiConfig, path + V2Endpoint.PATH_ONTOLOGIES);
-        this.res = new ResourcesEndpoint(knoraApiConfig, path + V2Endpoint.PATH_RESOURCES);
+        this.res = new ResourcesEndpoint(knoraApiConfig, path + V2Endpoint.PATH_RESOURCES, this);
         this.list = new ListsEndpoint(knoraApiConfig, path);
-        this.search = new SearchEndpoint(knoraApiConfig, path);
+        this.search = new SearchEndpoint(knoraApiConfig, path, this);
 
+        // Instantiate caches
+        this.ontologyCache = new OntologyCache(knoraApiConfig, this);
     }
-
-    // </editor-fold>
-
-    /////////////
-    // METHODS //
-    /////////////
-
-    // <editor-fold desc="">
-    // </editor-fold>
 
 }

--- a/src/api/v2/v2-endpoint.ts
+++ b/src/api/v2/v2-endpoint.ts
@@ -1,4 +1,4 @@
-import { OntologyCache } from "../..";
+import { OntologyCache } from "../../cache/OntologyCache";
 import { KnoraApiConfig } from "../../knora-api-config";
 import { Endpoint } from "../endpoint";
 import { AuthenticationEndpoint } from "./authentication/authentication-endpoint";

--- a/src/cache/ListNodeCache.spec.ts
+++ b/src/cache/ListNodeCache.spec.ts
@@ -10,11 +10,10 @@ import { ListNodeCache } from "./ListNodeCache";
 describe("ListNodeCache", () => {
 
     const config = new KnoraApiConfig("http", "0.0.0.0", 3333, "", "", true);
-    const knoraApiConnection = new KnoraApiConnection(config);
+    let knoraApiConnection: KnoraApiConnection;
 
     let getNodeSpy: jasmine.Spy;
     let getListSpy: jasmine.Spy;
-    let listNodeCache: ListNodeCache;
 
     const jsonConvert: JsonConvert = new JsonConvert(
         OperationMode.ENABLE,
@@ -25,6 +24,8 @@ describe("ListNodeCache", () => {
 
     beforeEach(() => {
         jasmine.Ajax.install();
+
+        knoraApiConnection  = new KnoraApiConnection(config);
 
         getNodeSpy = spyOn(knoraApiConnection.v2.list, "getNode").and.callFake(
             (nodeIri: string) => {
@@ -42,8 +43,6 @@ describe("ListNodeCache", () => {
             }
         );
 
-        listNodeCache = new ListNodeCache(knoraApiConnection);
-
     });
 
     afterEach(() => {
@@ -54,7 +53,7 @@ describe("ListNodeCache", () => {
 
         it("should get a list node from the cache", done => {
 
-            listNodeCache["getItem"]("http://rdfh.ch/lists/0001/treeList01").subscribe((node: ListNode) => {
+            knoraApiConnection.v2.listNodeCache["getItem"]("http://rdfh.ch/lists/0001/treeList01").subscribe((node: ListNode) => {
 
                 expect(node.id).toEqual("http://rdfh.ch/lists/0001/treeList01");
 
@@ -64,14 +63,14 @@ describe("ListNodeCache", () => {
                 expect(getListSpy).toHaveBeenCalledTimes(1);
                 expect(getListSpy).toHaveBeenCalledWith("http://rdfh.ch/lists/0001/treeList");
 
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]["hasCompleted"]).toBeTruthy();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]["hasCompleted"]).toBeTruthy();
 
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList"]).not.toBeUndefined(); // root node Iri is dependency of each list node
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList02"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList03"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList10"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList11"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList"]).not.toBeUndefined(); // root node Iri is dependency of each list node
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList02"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList03"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList10"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList11"]).not.toBeUndefined();
 
                 done();
 
@@ -80,7 +79,7 @@ describe("ListNodeCache", () => {
 
         it("should get a list node from the cache several times asynchronously", done => {
 
-            listNodeCache["getItem"]("http://rdfh.ch/lists/0001/treeList01").subscribe((node: ListNode) => {
+            knoraApiConnection.v2.listNodeCache["getItem"]("http://rdfh.ch/lists/0001/treeList01").subscribe((node: ListNode) => {
 
                 expect(node.id).toEqual("http://rdfh.ch/lists/0001/treeList01");
 
@@ -90,20 +89,20 @@ describe("ListNodeCache", () => {
                 expect(getListSpy).toHaveBeenCalledTimes(1);
                 expect(getListSpy).toHaveBeenCalledWith("http://rdfh.ch/lists/0001/treeList");
 
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]["hasCompleted"]).toBeTruthy();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]["hasCompleted"]).toBeTruthy();
 
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList"]).not.toBeUndefined(); // root node Iri is dependency of each list node
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList02"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList03"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList10"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList11"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList"]).not.toBeUndefined(); // root node Iri is dependency of each list node
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList02"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList03"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList10"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList11"]).not.toBeUndefined();
 
                 done();
 
             });
 
-            listNodeCache["getItem"]("http://rdfh.ch/lists/0001/treeList01").subscribe((node: ListNode) => {
+            knoraApiConnection.v2.listNodeCache["getItem"]("http://rdfh.ch/lists/0001/treeList01").subscribe((node: ListNode) => {
 
                 expect(node.id).toEqual("http://rdfh.ch/lists/0001/treeList01");
 
@@ -113,20 +112,20 @@ describe("ListNodeCache", () => {
                 expect(getListSpy).toHaveBeenCalledTimes(1);
                 expect(getListSpy).toHaveBeenCalledWith("http://rdfh.ch/lists/0001/treeList");
 
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]["hasCompleted"]).toBeTruthy();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]["hasCompleted"]).toBeTruthy();
 
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList"]).not.toBeUndefined(); // root node Iri is dependency of each list node
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList02"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList03"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList10"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList11"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList"]).not.toBeUndefined(); // root node Iri is dependency of each list node
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList02"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList03"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList10"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList11"]).not.toBeUndefined();
 
                 done();
 
             });
 
-            listNodeCache["getItem"]("http://rdfh.ch/lists/0001/treeList01").subscribe((node: ListNode) => {
+            knoraApiConnection.v2.listNodeCache["getItem"]("http://rdfh.ch/lists/0001/treeList01").subscribe((node: ListNode) => {
 
                 expect(node.id).toEqual("http://rdfh.ch/lists/0001/treeList01");
 
@@ -136,14 +135,14 @@ describe("ListNodeCache", () => {
                 expect(getListSpy).toHaveBeenCalledTimes(1);
                 expect(getListSpy).toHaveBeenCalledWith("http://rdfh.ch/lists/0001/treeList");
 
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]["hasCompleted"]).toBeTruthy();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]["hasCompleted"]).toBeTruthy();
 
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList"]).not.toBeUndefined(); // root node Iri is dependency of each list node
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList02"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList03"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList10"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList11"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList"]).not.toBeUndefined(); // root node Iri is dependency of each list node
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList02"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList03"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList10"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList11"]).not.toBeUndefined();
 
                 done();
 
@@ -156,7 +155,7 @@ describe("ListNodeCache", () => {
 
         it("should get a list node from the cache", done => {
 
-            listNodeCache.getNode("http://rdfh.ch/lists/0001/treeList01").subscribe((node: ListNode) => {
+            knoraApiConnection.v2.listNodeCache.getNode("http://rdfh.ch/lists/0001/treeList01").subscribe((node: ListNode) => {
 
                 expect(node.id).toEqual("http://rdfh.ch/lists/0001/treeList01");
 
@@ -166,14 +165,14 @@ describe("ListNodeCache", () => {
                 expect(getListSpy).toHaveBeenCalledTimes(1);
                 expect(getListSpy).toHaveBeenCalledWith("http://rdfh.ch/lists/0001/treeList");
 
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]["hasCompleted"]).toBeTruthy();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList01"]["hasCompleted"]).toBeTruthy();
 
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList"]).not.toBeUndefined(); // root node Iri is dependency of each list node
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList02"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList03"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList10"]).not.toBeUndefined();
-                expect(listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList11"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList"]).not.toBeUndefined(); // root node Iri is dependency of each list node
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList02"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList03"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList10"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.listNodeCache["cache"]["http://rdfh.ch/lists/0001/treeList11"]).not.toBeUndefined();
 
                 done();
 

--- a/src/cache/ListNodeCache.ts
+++ b/src/cache/ListNodeCache.ts
@@ -1,5 +1,7 @@
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
+import { V2Endpoint } from "../api/v2/v2-endpoint";
+import { KnoraApiConfig } from "../knora-api-config";
 import { KnoraApiConnection } from "../knora-api-connection";
 import { ListConversionUtil } from "../models/v2/lists/list-conversion-util";
 import { ListNode } from "../models/v2/lists/list-node";
@@ -11,7 +13,7 @@ import { GenericCache } from "./GenericCache";
  */
 export class ListNodeCache extends GenericCache<ListNode> {
 
-    constructor(private knoraApiConnection: KnoraApiConnection) {
+    constructor(private v2Endpoint: V2Endpoint) {
         super();
     }
 
@@ -34,11 +36,11 @@ export class ListNodeCache extends GenericCache<ListNode> {
     protected requestItemFromKnora(key: string, isDependency: boolean): Observable<ListNode[]> {
         if (!isDependency) {
             // not a dependency, get the list node
-            return this.knoraApiConnection.v2.list.getNode(key)
+            return this.v2Endpoint.list.getNode(key)
                 .pipe(map((node: ListNode) => [node]));
         } else {
             // a dependency, get the whole list
-            const list = this.knoraApiConnection.v2.list.getList(key);
+            const list = this.v2Endpoint.list.getList(key);
 
             return (list as Observable<ListNode>).pipe(
                 map(

--- a/src/cache/OntologyCache.spec.ts
+++ b/src/cache/OntologyCache.spec.ts
@@ -9,14 +9,15 @@ import { ResourceClassDefinition } from "../models/v2/ontologies/resource-class-
 describe("OntologyCache", () => {
 
     const config = new KnoraApiConfig("http", "0.0.0.0", 3333, "", "", true);
-    const knoraApiConnection = new KnoraApiConnection(config);
+    let knoraApiConnection: KnoraApiConnection;
 
     let getOntoSpy: jasmine.Spy;
-    let ontoCache: OntologyCache;
 
     beforeEach(() => {
 
         jasmine.Ajax.install();
+
+        knoraApiConnection = new KnoraApiConnection(config);
 
         getOntoSpy = spyOn(knoraApiConnection.v2.onto, "getOntology").and.callFake(
             (ontoIri: string) => {
@@ -26,8 +27,6 @@ describe("OntologyCache", () => {
                 return of(onto);
             }
         );
-
-        ontoCache = new OntologyCache(knoraApiConnection, config);
 
     });
 
@@ -39,7 +38,7 @@ describe("OntologyCache", () => {
 
         it("should get an ontology with dependencies from the cache", done => {
 
-            ontoCache["getItem"]("http://0.0.0.0:3333/ontology/0001/anything/v2").subscribe((onto: ReadOntology) => {
+            knoraApiConnection.v2.ontologyCache["getItem"]("http://0.0.0.0:3333/ontology/0001/anything/v2").subscribe((onto: ReadOntology) => {
 
                 expect(onto.id).toEqual("http://0.0.0.0:3333/ontology/0001/anything/v2");
 
@@ -47,8 +46,8 @@ describe("OntologyCache", () => {
                 expect(getOntoSpy).toHaveBeenCalledWith("http://0.0.0.0:3333/ontology/0001/anything/v2");
                 expect(getOntoSpy).toHaveBeenCalledWith("http://api.knora.org/ontology/knora-api/v2"); // anything onto depends on knora-api
 
-                expect(ontoCache["cache"]["http://0.0.0.0:3333/ontology/0001/anything/v2"]).not.toBeUndefined();
-                expect(ontoCache["cache"]["http://api.knora.org/ontology/knora-api/v2"]).not.toBeUndefined(); // anything onto depends on knora-api
+                expect(knoraApiConnection.v2.ontologyCache["cache"]["http://0.0.0.0:3333/ontology/0001/anything/v2"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.ontologyCache["cache"]["http://api.knora.org/ontology/knora-api/v2"]).not.toBeUndefined(); // anything onto depends on knora-api
                 done();
 
             });
@@ -56,7 +55,7 @@ describe("OntologyCache", () => {
 
         it("should get an ontology with dependencies from the cache several times asynchronously", done => {
 
-            ontoCache["getItem"]("http://0.0.0.0:3333/ontology/0001/anything/v2").subscribe((onto: ReadOntology) => {
+            knoraApiConnection.v2.ontologyCache["getItem"]("http://0.0.0.0:3333/ontology/0001/anything/v2").subscribe((onto: ReadOntology) => {
 
                 expect(onto.id).toEqual("http://0.0.0.0:3333/ontology/0001/anything/v2");
 
@@ -64,13 +63,13 @@ describe("OntologyCache", () => {
                 expect(getOntoSpy).toHaveBeenCalledWith("http://0.0.0.0:3333/ontology/0001/anything/v2");
                 expect(getOntoSpy).toHaveBeenCalledWith("http://api.knora.org/ontology/knora-api/v2"); // anything onto depends on knora-api
 
-                expect(ontoCache["cache"]["http://0.0.0.0:3333/ontology/0001/anything/v2"]).not.toBeUndefined();
-                expect(ontoCache["cache"]["http://api.knora.org/ontology/knora-api/v2"]).not.toBeUndefined(); // anything onto depends on knora-api
+                expect(knoraApiConnection.v2.ontologyCache["cache"]["http://0.0.0.0:3333/ontology/0001/anything/v2"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.ontologyCache["cache"]["http://api.knora.org/ontology/knora-api/v2"]).not.toBeUndefined(); // anything onto depends on knora-api
                 done();
 
             });
 
-            ontoCache["getItem"]("http://0.0.0.0:3333/ontology/0001/anything/v2").subscribe((onto: ReadOntology) => {
+            knoraApiConnection.v2.ontologyCache["getItem"]("http://0.0.0.0:3333/ontology/0001/anything/v2").subscribe((onto: ReadOntology) => {
 
                 expect(onto.id).toEqual("http://0.0.0.0:3333/ontology/0001/anything/v2");
 
@@ -78,13 +77,13 @@ describe("OntologyCache", () => {
                 expect(getOntoSpy).toHaveBeenCalledWith("http://0.0.0.0:3333/ontology/0001/anything/v2");
                 expect(getOntoSpy).toHaveBeenCalledWith("http://api.knora.org/ontology/knora-api/v2"); // anything onto depends on knora-api
 
-                expect(ontoCache["cache"]["http://0.0.0.0:3333/ontology/0001/anything/v2"]).not.toBeUndefined();
-                expect(ontoCache["cache"]["http://api.knora.org/ontology/knora-api/v2"]).not.toBeUndefined(); // anything onto depends on knora-api
+                expect(knoraApiConnection.v2.ontologyCache["cache"]["http://0.0.0.0:3333/ontology/0001/anything/v2"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.ontologyCache["cache"]["http://api.knora.org/ontology/knora-api/v2"]).not.toBeUndefined(); // anything onto depends on knora-api
                 done();
 
             });
 
-            ontoCache["getItem"]("http://0.0.0.0:3333/ontology/0001/anything/v2").subscribe((onto: ReadOntology) => {
+            knoraApiConnection.v2.ontologyCache["getItem"]("http://0.0.0.0:3333/ontology/0001/anything/v2").subscribe((onto: ReadOntology) => {
 
                 expect(onto.id).toEqual("http://0.0.0.0:3333/ontology/0001/anything/v2");
 
@@ -92,8 +91,8 @@ describe("OntologyCache", () => {
                 expect(getOntoSpy).toHaveBeenCalledWith("http://0.0.0.0:3333/ontology/0001/anything/v2");
                 expect(getOntoSpy).toHaveBeenCalledWith("http://api.knora.org/ontology/knora-api/v2"); // anything onto depends on knora-api
 
-                expect(ontoCache["cache"]["http://0.0.0.0:3333/ontology/0001/anything/v2"]).not.toBeUndefined();
-                expect(ontoCache["cache"]["http://api.knora.org/ontology/knora-api/v2"]).not.toBeUndefined(); // anything onto depends on knora-api
+                expect(knoraApiConnection.v2.ontologyCache["cache"]["http://0.0.0.0:3333/ontology/0001/anything/v2"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.ontologyCache["cache"]["http://api.knora.org/ontology/knora-api/v2"]).not.toBeUndefined(); // anything onto depends on knora-api
                 done();
 
             });
@@ -101,14 +100,14 @@ describe("OntologyCache", () => {
 
         it("should get an ontology without dependencies from the cache", done => {
 
-            ontoCache["getItem"]("http://api.knora.org/ontology/knora-api/v2").subscribe((onto: ReadOntology) => {
+            knoraApiConnection.v2.ontologyCache["getItem"]("http://api.knora.org/ontology/knora-api/v2").subscribe((onto: ReadOntology) => {
 
                 expect(onto.id).toEqual("http://api.knora.org/ontology/knora-api/v2");
 
                 expect(getOntoSpy).toHaveBeenCalledTimes(1);
                 expect(getOntoSpy).toHaveBeenCalledWith("http://api.knora.org/ontology/knora-api/v2");
 
-                expect(ontoCache["cache"]["http://api.knora.org/ontology/knora-api/v2"]).not.toBeUndefined();
+                expect(knoraApiConnection.v2.ontologyCache["cache"]["http://api.knora.org/ontology/knora-api/v2"]).not.toBeUndefined();
                 done();
 
             });
@@ -120,7 +119,7 @@ describe("OntologyCache", () => {
 
         it("should get an ontology with direct dependencies from the cache", done => {
 
-            ontoCache.getOntology("http://0.0.0.0:3333/ontology/0001/anything/v2").subscribe(ontos => {
+            knoraApiConnection.v2.ontologyCache.getOntology("http://0.0.0.0:3333/ontology/0001/anything/v2").subscribe(ontos => {
 
                 expect(ontos.size).toEqual(2);
                 expect(ontos.has("http://0.0.0.0:3333/ontology/0001/anything/v2")).toBeTruthy();
@@ -141,7 +140,7 @@ describe("OntologyCache", () => {
 
         it("should get an ontology without dependencies from the cache", done => {
 
-            ontoCache.getOntology("http://api.knora.org/ontology/knora-api/v2").subscribe(ontos => {
+            knoraApiConnection.v2.ontologyCache.getOntology("http://api.knora.org/ontology/knora-api/v2").subscribe(ontos => {
 
                 expect(ontos.size).toEqual(1);
                 expect(ontos.has("http://api.knora.org/ontology/knora-api/v2")).toBeTruthy();
@@ -163,21 +162,13 @@ describe("OntologyCache", () => {
 
         it("should get the definition of a resource class and its properties", done => {
 
-            ontoCache.getResourceClassDefinition("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing").subscribe(
+            knoraApiConnection.v2.ontologyCache.getResourceClassDefinition("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing").subscribe(
                 resClassDef => {
 
                     expect(resClassDef.classes["http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"] instanceof ResourceClassDefinition).toBeTruthy();
                     expect(Object.keys(resClassDef.properties).length).toEqual(35);
 
                     done();
-
-                    /*resClassDef.classes["http://0.0.0.0:3333/ontology/0001/anything/v2#Thing"].propertiesList.forEach(prop => console.log(prop.propertyIndex));
-                    console.log("+++++")
-                    const propKeys = Object.keys(resClassDef.properties);
-                    propKeys.forEach(key => {
-                        console.log(resClassDef.properties[key].id);
-                        console.log(resClassDef.properties[key]);
-                    });*/
 
                 }
             );

--- a/src/cache/OntologyCache.spec.ts
+++ b/src/cache/OntologyCache.spec.ts
@@ -1,5 +1,4 @@
 import { of } from "rxjs";
-import { OntologyCache } from "..";
 import { MockOntology } from "../../test/data/api/v2/mockOntology";
 import { KnoraApiConfig } from "../knora-api-config";
 import { KnoraApiConnection } from "../knora-api-connection";

--- a/src/cache/OntologyCache.ts
+++ b/src/cache/OntologyCache.ts
@@ -1,6 +1,7 @@
 import { AsyncSubject, forkJoin, Observable, of } from "rxjs";
 import { map, mergeMap } from "rxjs/operators";
 import { KnoraApiConfig, KnoraApiConnection } from "..";
+import { V2Endpoint } from "../api/v2/v2-endpoint";
 import { ClassDefinition, IHasProperty } from "../models/v2/ontologies/class-definition";
 import { OntologyConversionUtil } from "../models/v2/ontologies/OntologyConversionUtil";
 import { PropertyDefinition } from "../models/v2/ontologies/property-definition";
@@ -29,7 +30,7 @@ export interface IResourceClassAndPropertyDefinitions {
  */
 export class OntologyCache extends GenericCache<ReadOntology> {
 
-    constructor(private knoraApiConnection: KnoraApiConnection, private knoraApiConfig: KnoraApiConfig) {
+    constructor(private knoraApiConfig: KnoraApiConfig, private v2Endpoint: V2Endpoint) {
         super();
     }
 
@@ -141,7 +142,7 @@ export class OntologyCache extends GenericCache<ReadOntology> {
     }
 
     protected requestItemFromKnora(key: string, isDependency: boolean): Observable<ReadOntology[]> {
-        return this.knoraApiConnection.v2.onto.getOntology(key).pipe(
+        return this.v2Endpoint.onto.getOntology(key).pipe(
             map((onto: ReadOntology) => [onto])
         );
     }

--- a/src/cache/OntologyCache.ts
+++ b/src/cache/OntologyCache.ts
@@ -1,6 +1,6 @@
 import { AsyncSubject, forkJoin, Observable, of } from "rxjs";
 import { map, mergeMap } from "rxjs/operators";
-import { KnoraApiConfig } from "..";
+import { KnoraApiConfig } from "../knora-api-config";
 import { V2Endpoint } from "../api/v2/v2-endpoint";
 import { ClassDefinition, IHasProperty } from "../models/v2/ontologies/class-definition";
 import { OntologyConversionUtil } from "../models/v2/ontologies/OntologyConversionUtil";

--- a/src/cache/OntologyCache.ts
+++ b/src/cache/OntologyCache.ts
@@ -1,6 +1,6 @@
 import { AsyncSubject, forkJoin, Observable, of } from "rxjs";
 import { map, mergeMap } from "rxjs/operators";
-import { KnoraApiConfig, KnoraApiConnection } from "..";
+import { KnoraApiConfig } from "..";
 import { V2Endpoint } from "../api/v2/v2-endpoint";
 import { ClassDefinition, IHasProperty } from "../models/v2/ontologies/class-definition";
 import { OntologyConversionUtil } from "../models/v2/ontologies/OntologyConversionUtil";

--- a/src/cache/UserCache.spec.ts
+++ b/src/cache/UserCache.spec.ts
@@ -1,9 +1,11 @@
 import { JsonConvert, OperationMode, ValueCheckingMode } from "json2typescript";
 import { PropertyMatchingRule } from "json2typescript/src/json2typescript/json-convert-enums";
 import { of } from "rxjs";
-import { ApiResponseData, ApiResponseError, UserResponse } from "..";
 import { KnoraApiConfig } from "../knora-api-config";
 import { KnoraApiConnection } from "../knora-api-connection";
+import { UserResponse } from "../models/admin/user-response";
+import { ApiResponseData } from "../models/api-response-data";
+import { ApiResponseError } from "../models/api-response-error";
 import { UserCache } from "./UserCache";
 
 describe("UserCache", () => {

--- a/src/cache/UserCache.ts
+++ b/src/cache/UserCache.ts
@@ -1,8 +1,8 @@
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
-import { ApiResponseData, UserResponse } from "..";
 import { KnoraApiConnection } from "../knora-api-connection";
-import { ReadOntology } from "../models/v2/ontologies/read-ontology";
+import { UserResponse } from "../models/admin/user-response";
+import { ApiResponseData } from "../models/api-response-data";
 import { GenericCache } from "./GenericCache";
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ export { LoginResponse } from "./models/v2/authentication/login-response";
 export { LogoutResponse } from "./models/v2/authentication/logout-response";
 
 export { UserCache } from "./cache/UserCache";
-export { ListNodeCache } from "./cache/ListNodeCache";
 
 export { ApiResponse } from "./models/api-response";
 export { ApiResponseData } from "./models/api-response-data";

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ export { LoginResponse } from "./models/v2/authentication/login-response";
 export { LogoutResponse } from "./models/v2/authentication/logout-response";
 
 export { UserCache } from "./cache/UserCache";
-export { OntologyCache } from "./cache/OntologyCache";
 export { ListNodeCache } from "./cache/ListNodeCache";
 
 export { ApiResponse } from "./models/api-response";

--- a/src/knora-api-connection.ts
+++ b/src/knora-api-connection.ts
@@ -7,22 +7,8 @@ import { KnoraApiConfig } from "./knora-api-config";
  */
 export class KnoraApiConnection {
 
-    ///////////////
-    // CONSTANTS //
-    ///////////////
-
-    // <editor-fold desc="">
-
     static readonly PATH_ADMIN = "/admin";
     static readonly PATH_V2 = "/v2";
-
-    // </editor-fold>
-
-    ////////////////
-    // PROPERTIES //
-    ////////////////
-
-    // <editor-fold desc="">
 
     /**
      * Holds all endpoints of the admin route
@@ -33,14 +19,6 @@ export class KnoraApiConnection {
      * Holds all endpoints of the v2 route
      */
     readonly v2: V2Endpoint;
-
-    // </editor-fold>
-
-    /////////////////
-    // CONSTRUCTOR //
-    /////////////////
-
-    // <editor-fold desc="">
 
     /**
      * Constructor.
@@ -55,14 +33,4 @@ export class KnoraApiConnection {
         // todo more
 
     }
-
-    // </editor-fold>
-
-    /////////////
-    // METHODS //
-    /////////////
-
-    // <editor-fold desc="">
-    // </editor-fold>
-
 }

--- a/src/models/v2/resources/ResourcesConversionUtil.spec.ts
+++ b/src/models/v2/resources/ResourcesConversionUtil.spec.ts
@@ -3,7 +3,6 @@ import { PropertyMatchingRule } from "json2typescript/src/json2typescript/json-c
 import { of } from "rxjs";
 import {
     ListNodeCache,
-    OntologyCache,
     ReadBooleanValue,
     ReadColorValue,
     ReadDecimalValue,
@@ -45,7 +44,7 @@ describe("ResourcesConversionUtil", () => {
     beforeEach(() => {
         jasmine.Ajax.install();
 
-        knoraApiConnection  = new KnoraApiConnection(config);
+        knoraApiConnection = new KnoraApiConnection(config);
 
         listNodeCache = new ListNodeCache(knoraApiConnection);
 

--- a/src/models/v2/resources/ResourcesConversionUtil.spec.ts
+++ b/src/models/v2/resources/ResourcesConversionUtil.spec.ts
@@ -2,7 +2,6 @@ import { JsonConvert, OperationMode, ValueCheckingMode } from "json2typescript";
 import { PropertyMatchingRule } from "json2typescript/src/json2typescript/json-convert-enums";
 import { of } from "rxjs";
 import {
-    ListNodeCache,
     ReadBooleanValue,
     ReadColorValue,
     ReadDecimalValue,
@@ -29,8 +28,6 @@ describe("ResourcesConversionUtil", () => {
     const config = new KnoraApiConfig("http", "0.0.0.0", 3333, undefined, "", true);
     let knoraApiConnection: KnoraApiConnection;
 
-    let listNodeCache: ListNodeCache;
-
     let getResourceClassDefinitionFromCacheSpy: jasmine.Spy;
     let getListNodeFromCacheSpy: jasmine.Spy;
 
@@ -46,8 +43,6 @@ describe("ResourcesConversionUtil", () => {
 
         knoraApiConnection = new KnoraApiConnection(config);
 
-        listNodeCache = new ListNodeCache(knoraApiConnection);
-
         getResourceClassDefinitionFromCacheSpy = spyOn(knoraApiConnection.v2.ontologyCache, "getResourceClassDefinition").and.callFake(
             (resClassIri: string) => {
                 const mock = MockOntology.mockIResourceClassAndPropertyDefinitions(resClassIri);
@@ -55,7 +50,7 @@ describe("ResourcesConversionUtil", () => {
             }
         );
 
-        getListNodeFromCacheSpy = spyOn(listNodeCache, "getNode").and.callFake(
+        getListNodeFromCacheSpy = spyOn(knoraApiConnection.v2.listNodeCache, "getNode").and.callFake(
             (listNodeIri: string) => {
                 return MockList.mockCompletedAsyncSubject(listNodeIri);
             }
@@ -73,7 +68,7 @@ describe("ResourcesConversionUtil", () => {
 
             const resource = require("../../../../test/data/api/v2/resources/testding-expanded.json");
 
-            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, listNodeCache, jsonConvert).subscribe(
+            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, knoraApiConnection.v2.listNodeCache, jsonConvert).subscribe(
                 resSeq => {
 
                     expect(resSeq.length).toEqual(1);
@@ -279,7 +274,7 @@ describe("ResourcesConversionUtil", () => {
 
             const resource = require("../../../../test/data/api/v2/resources/page-expanded.json");
 
-            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, listNodeCache, jsonConvert).subscribe(
+            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, knoraApiConnection.v2.listNodeCache, jsonConvert).subscribe(
                 resSeq => {
 
                     // console.log(resSeq[0].properties);
@@ -296,7 +291,7 @@ describe("ResourcesConversionUtil", () => {
 
             const resource = require("../../../../test/data/api/v2/resources/regions-expanded.json");
 
-            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, listNodeCache, jsonConvert).subscribe(
+            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, knoraApiConnection.v2.listNodeCache, jsonConvert).subscribe(
                 resSeq => {
 
                     expect(resSeq.length).toEqual(2);
@@ -317,7 +312,7 @@ describe("ResourcesConversionUtil", () => {
 
             const emptyResource = {};
 
-            ResourcesConversionUtil.createReadResourceSequence(emptyResource, knoraApiConnection.v2.ontologyCache, listNodeCache, jsonConvert).subscribe(
+            ResourcesConversionUtil.createReadResourceSequence(emptyResource, knoraApiConnection.v2.ontologyCache, knoraApiConnection.v2.listNodeCache, jsonConvert).subscribe(
                 resSeq => {
                     expect(resSeq.length).toEqual(0);
                     expect(getResourceClassDefinitionFromCacheSpy).toHaveBeenCalledTimes(0);
@@ -332,7 +327,7 @@ describe("ResourcesConversionUtil", () => {
 
             const resource = require("../../../../test/data/api/v2/resources/things-expanded.json");
 
-            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, listNodeCache, jsonConvert).subscribe(
+            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, knoraApiConnection.v2.listNodeCache, jsonConvert).subscribe(
                 resSeq => {
                     expect(resSeq.length).toEqual(2);
 

--- a/src/models/v2/resources/ResourcesConversionUtil.spec.ts
+++ b/src/models/v2/resources/ResourcesConversionUtil.spec.ts
@@ -1,17 +1,17 @@
 import { JsonConvert, OperationMode, ValueCheckingMode } from "json2typescript";
 import { PropertyMatchingRule } from "json2typescript/src/json2typescript/json-convert-enums";
-import { AsyncSubject, of } from "rxjs";
+import { of } from "rxjs";
 import {
     ListNodeCache,
     OntologyCache,
     ReadBooleanValue,
     ReadColorValue,
-    ReadDecimalValue, ReadGeomValue,
+    ReadDecimalValue,
+    ReadGeomValue,
     ReadIntervalValue,
     ReadIntValue,
     ReadLinkValue,
     ReadResource,
-    ReadTextValue,
     ReadTextValueAsString,
     ReadTextValueAsXml
 } from "../../..";
@@ -19,21 +19,18 @@ import { MockList } from "../../../../test/data/api/v2/mockList";
 import { MockOntology } from "../../../../test/data/api/v2/mockOntology";
 import { KnoraApiConfig } from "../../../knora-api-config";
 import { KnoraApiConnection } from "../../../knora-api-connection";
-import { ListNode } from "../lists/list-node";
 import { ResourcesConversionUtil } from "./ResourcesConversionUtil";
+import { KnoraDate, Precision, ReadDateValue } from "./values/read-date-value";
 import { Point2D, RegionGeometry } from "./values/read-geom-value";
 import { ReadListValue } from "./values/read-list-value";
 import { ReadUriValue } from "./values/read-uri-value";
-import { KnoraDate, Precision, ReadDateValue } from "./values/read-date-value";
-import { ReadValue } from "./values/read-value";
 
 describe("ResourcesConversionUtil", () => {
 
     const config = new KnoraApiConfig("http", "0.0.0.0", 3333, undefined, "", true);
-    const knoraApiConnection = new KnoraApiConnection(config);
+    let knoraApiConnection: KnoraApiConnection;
 
-    const ontoCache = new OntologyCache(knoraApiConnection, config);
-    const listNodeCache = new ListNodeCache(knoraApiConnection);
+    let listNodeCache: ListNodeCache;
 
     let getResourceClassDefinitionFromCacheSpy: jasmine.Spy;
     let getListNodeFromCacheSpy: jasmine.Spy;
@@ -48,7 +45,11 @@ describe("ResourcesConversionUtil", () => {
     beforeEach(() => {
         jasmine.Ajax.install();
 
-        getResourceClassDefinitionFromCacheSpy = spyOn(ontoCache, "getResourceClassDefinition").and.callFake(
+        knoraApiConnection  = new KnoraApiConnection(config);
+
+        listNodeCache = new ListNodeCache(knoraApiConnection);
+
+        getResourceClassDefinitionFromCacheSpy = spyOn(knoraApiConnection.v2.ontologyCache, "getResourceClassDefinition").and.callFake(
             (resClassIri: string) => {
                 const mock = MockOntology.mockIResourceClassAndPropertyDefinitions(resClassIri);
                 return of(mock);
@@ -73,7 +74,7 @@ describe("ResourcesConversionUtil", () => {
 
             const resource = require("../../../../test/data/api/v2/resources/testding-expanded.json");
 
-            ResourcesConversionUtil.createReadResourceSequence(resource, ontoCache, listNodeCache, jsonConvert).subscribe(
+            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, listNodeCache, jsonConvert).subscribe(
                 resSeq => {
 
                     expect(resSeq.length).toEqual(1);
@@ -279,7 +280,7 @@ describe("ResourcesConversionUtil", () => {
 
             const resource = require("../../../../test/data/api/v2/resources/page-expanded.json");
 
-            ResourcesConversionUtil.createReadResourceSequence(resource, ontoCache, listNodeCache, jsonConvert).subscribe(
+            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, listNodeCache, jsonConvert).subscribe(
                 resSeq => {
 
                     // console.log(resSeq[0].properties);
@@ -296,7 +297,7 @@ describe("ResourcesConversionUtil", () => {
 
             const resource = require("../../../../test/data/api/v2/resources/regions-expanded.json");
 
-            ResourcesConversionUtil.createReadResourceSequence(resource, ontoCache, listNodeCache, jsonConvert).subscribe(
+            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, listNodeCache, jsonConvert).subscribe(
                 resSeq => {
 
                     expect(resSeq.length).toEqual(2);
@@ -317,7 +318,7 @@ describe("ResourcesConversionUtil", () => {
 
             const emptyResource = {};
 
-            ResourcesConversionUtil.createReadResourceSequence(emptyResource, ontoCache, listNodeCache, jsonConvert).subscribe(
+            ResourcesConversionUtil.createReadResourceSequence(emptyResource, knoraApiConnection.v2.ontologyCache, listNodeCache, jsonConvert).subscribe(
                 resSeq => {
                     expect(resSeq.length).toEqual(0);
                     expect(getResourceClassDefinitionFromCacheSpy).toHaveBeenCalledTimes(0);
@@ -332,7 +333,7 @@ describe("ResourcesConversionUtil", () => {
 
             const resource = require("../../../../test/data/api/v2/resources/things-expanded.json");
 
-            ResourcesConversionUtil.createReadResourceSequence(resource, ontoCache, listNodeCache, jsonConvert).subscribe(
+            ResourcesConversionUtil.createReadResourceSequence(resource, knoraApiConnection.v2.ontologyCache, listNodeCache, jsonConvert).subscribe(
                 resSeq => {
                     expect(resSeq.length).toEqual(2);
 

--- a/src/models/v2/resources/ResourcesConversionUtil.spec.ts
+++ b/src/models/v2/resources/ResourcesConversionUtil.spec.ts
@@ -1,26 +1,22 @@
 import { JsonConvert, OperationMode, ValueCheckingMode } from "json2typescript";
 import { PropertyMatchingRule } from "json2typescript/src/json2typescript/json-convert-enums";
 import { of } from "rxjs";
-import {
-    ReadBooleanValue,
-    ReadColorValue,
-    ReadDecimalValue,
-    ReadGeomValue,
-    ReadIntervalValue,
-    ReadIntValue,
-    ReadLinkValue,
-    ReadResource,
-    ReadTextValueAsString,
-    ReadTextValueAsXml
-} from "../../..";
 import { MockList } from "../../../../test/data/api/v2/mockList";
 import { MockOntology } from "../../../../test/data/api/v2/mockOntology";
 import { KnoraApiConfig } from "../../../knora-api-config";
 import { KnoraApiConnection } from "../../../knora-api-connection";
+import { ReadResource } from "./read-resource";
 import { ResourcesConversionUtil } from "./ResourcesConversionUtil";
+import { ReadBooleanValue } from "./values/read-boolean-value";
+import { ReadColorValue } from "./values/read-color-value";
 import { KnoraDate, Precision, ReadDateValue } from "./values/read-date-value";
-import { Point2D, RegionGeometry } from "./values/read-geom-value";
+import { ReadDecimalValue } from "./values/read-decimal-value";
+import { Point2D, ReadGeomValue, RegionGeometry } from "./values/read-geom-value";
+import { ReadIntValue } from "./values/read-int-value";
+import { ReadIntervalValue } from "./values/read-interval-value";
+import { ReadLinkValue } from "./values/read-link-value";
 import { ReadListValue } from "./values/read-list-value";
+import { ReadTextValueAsString, ReadTextValueAsXml } from "./values/read-text-value";
 import { ReadUriValue } from "./values/read-uri-value";
 
 describe("ResourcesConversionUtil", () => {

--- a/src/models/v2/resources/ResourcesConversionUtil.ts
+++ b/src/models/v2/resources/ResourcesConversionUtil.ts
@@ -1,8 +1,8 @@
 import { JsonConvert } from "json2typescript";
 import { forkJoin, Observable, of } from "rxjs";
 import { map, mergeMap } from "rxjs/operators";
-import { ListNodeCache, OntologyCache } from "../../../";
-import { IResourceClassAndPropertyDefinitions } from "../../../cache/OntologyCache";
+import { ListNodeCache } from "../../../";
+import { IResourceClassAndPropertyDefinitions, OntologyCache } from "../../../cache/OntologyCache";
 import { Constants } from "../Constants";
 import { ResourcePropertyDefinition } from "../ontologies/resource-property-definition";
 import { CountQueryResponse } from "../search/count-query-response";

--- a/src/models/v2/resources/ResourcesConversionUtil.ts
+++ b/src/models/v2/resources/ResourcesConversionUtil.ts
@@ -1,7 +1,7 @@
 import { JsonConvert } from "json2typescript";
 import { forkJoin, Observable, of } from "rxjs";
 import { map, mergeMap } from "rxjs/operators";
-import { ListNodeCache } from "../../../";
+import { ListNodeCache } from "../../../cache/ListNodeCache";
 import { IResourceClassAndPropertyDefinitions, OntologyCache } from "../../../cache/OntologyCache";
 import { Constants } from "../Constants";
 import { ResourcePropertyDefinition } from "../ontologies/resource-property-definition";


### PR DESCRIPTION
Caches are instantiated in the v2 endpoint at construction time so the client does not have to do instantiate caches.

closes #78