### PR TITLE
fix (admin api): use json2typescript when serializing payload

### DIFF
--- a/src/api/admin/groups/groups-endpoint.ts
+++ b/src/api/admin/groups/groups-endpoint.ts
@@ -35,7 +35,7 @@ export class GroupsEndpoint extends Endpoint {
      */
     createGroup(group: CreateGroupRequest): Observable<ApiResponseData<GroupResponse> | ApiResponseError> {
     
-        return this.httpPost("", group).pipe(
+        return this.httpPost("", this.jsonConvert.serializeObject(group)).pipe(
             map(ajaxResponse => ApiResponseData.fromAjaxResponse(ajaxResponse, GroupResponse, this.jsonConvert)),
             catchError(error => this.handleError(error))
         );
@@ -64,7 +64,7 @@ export class GroupsEndpoint extends Endpoint {
      */
     updateGroup(iri: string, groupInfo: UpdateGroupRequest): Observable<ApiResponseData<GroupResponse> | ApiResponseError> {
     
-        return this.httpPut("/" + encodeURIComponent(iri), groupInfo).pipe(
+        return this.httpPut("/" + encodeURIComponent(iri), this.jsonConvert.serializeObject(groupInfo)).pipe(
             map(ajaxResponse => ApiResponseData.fromAjaxResponse(ajaxResponse, GroupResponse, this.jsonConvert)),
             catchError(error => this.handleError(error))
         );

--- a/src/api/admin/projects/projects-endpoint.ts
+++ b/src/api/admin/projects/projects-endpoint.ts
@@ -37,7 +37,7 @@ export class ProjectsEndpoint extends Endpoint {
      */
     createProject(project: Project): Observable<ApiResponseData<ProjectResponse> | ApiResponseError> {
     
-        return this.httpPost("", project).pipe(
+        return this.httpPost("", this.jsonConvert.serializeObject(project)).pipe(
             map(ajaxResponse => ApiResponseData.fromAjaxResponse(ajaxResponse, ProjectResponse, this.jsonConvert)),
             catchError(error => this.handleError(error))
         );
@@ -78,7 +78,7 @@ export class ProjectsEndpoint extends Endpoint {
      */
     updateProject(iri: string, projectInfo: UpdateProjectRequest): Observable<ApiResponseData<ProjectResponse> | ApiResponseError> {
     
-        return this.httpPut("/iri/" + encodeURIComponent(iri), projectInfo).pipe(
+        return this.httpPut("/iri/" + encodeURIComponent(iri), this.jsonConvert.serializeObject(projectInfo)).pipe(
             map(ajaxResponse => ApiResponseData.fromAjaxResponse(ajaxResponse, ProjectResponse, this.jsonConvert)),
             catchError(error => this.handleError(error))
         );

--- a/src/api/admin/users/users-endpoint.ts
+++ b/src/api/admin/users/users-endpoint.ts
@@ -127,7 +127,7 @@ export class UsersEndpoint extends Endpoint {
      */
     createUser(user: User): Observable<ApiResponseData<UserResponse> | ApiResponseError> {
     
-        return this.httpPost("", user).pipe(
+        return this.httpPost("", this.jsonConvert.serializeObject(user)).pipe(
             map(ajaxResponse => ApiResponseData.fromAjaxResponse(ajaxResponse, UserResponse, this.jsonConvert)),
             catchError(error => this.handleError(error))
         );
@@ -142,7 +142,7 @@ export class UsersEndpoint extends Endpoint {
      */
     updateUserBasicInformation(iri: string, userInfo: UpdateUserRequest): Observable<ApiResponseData<UserResponse> | ApiResponseError> {
     
-        return this.httpPut("/iri/" + encodeURIComponent(iri) + "/BasicUserInformation", userInfo).pipe(
+        return this.httpPut("/iri/" + encodeURIComponent(iri) + "/BasicUserInformation", this.jsonConvert.serializeObject(userInfo)).pipe(
             map(ajaxResponse => ApiResponseData.fromAjaxResponse(ajaxResponse, UserResponse, this.jsonConvert)),
             catchError(error => this.handleError(error))
         );


### PR DESCRIPTION
The code should be generated like this in Knora: for put and post operations with payload, `this.jsonConvert.serializeObject(payload)` should be called. 

relates to #97