### PR TITLE
Test Framework: Do Not Check for Exact Number of Search Results in E2E Tests

### DIFF
--- a/test-framework/e2e/src/app.e2e-spec.ts
+++ b/test-framework/e2e/src/app.e2e-spec.ts
@@ -1,6 +1,16 @@
 import {AppPage} from './app.po';
 import {browser, logging} from 'protractor';
 
+/**
+ * Attempts to convert a string to a number.
+ *
+ * @param numStr string to be converted to a number.
+ */
+const convertTextToNumber = (numStr): number => {
+  if (isNaN(numStr)) throw new Error(`${numStr} cannot be converted to a number`);
+  return Number(numStr);
+}
+
 describe('workspace-project App', () => {
   let page: AppPage;
 
@@ -143,7 +153,7 @@ describe('workspace-project App', () => {
 
     const size = page.getEle('div section#search span.size');
 
-    expect(size.getText()).toEqual('21');
+    expect(size.getText().then(convertTextToNumber)).toBeGreaterThan(0);
 
   });
 
@@ -157,7 +167,7 @@ describe('workspace-project App', () => {
 
     const size = page.getEle('div section#search span.size');
 
-    expect(size.getText()).toEqual('21');
+    expect(size.getText().then(convertTextToNumber)).toBeGreaterThan(0);
 
   });
 
@@ -171,7 +181,7 @@ describe('workspace-project App', () => {
 
     const size = page.getEle('div section#search span.size');
 
-    expect(size.getText()).toEqual('21');
+    expect(size.getText().then(convertTextToNumber)).toBeGreaterThan(0);
 
   });
 
@@ -185,7 +195,7 @@ describe('workspace-project App', () => {
 
     const size = page.getEle('div section#search span.size');
 
-    expect(size.getText()).toEqual('25');
+    expect(size.getText().then(convertTextToNumber)).toBeGreaterThan(0);
 
   });
 
@@ -199,7 +209,7 @@ describe('workspace-project App', () => {
 
     const size = page.getEle('div section#search span.size');
 
-    expect(size.getText()).toEqual('48');
+    expect(size.getText().then(convertTextToNumber)).toBeGreaterThan(0);
 
   });
 


### PR DESCRIPTION
This PR changes the assertions in the E2E tests so that search tests do not expect an exact number of results (see https://github.com/dasch-swiss/knora-api/pull/1615#issuecomment-610252259). The data can always change in knora-api, but this is irrelevant to these tests. They just have to make sure that the result can be obtained and deserialized correctly.