### PR TITLE
Make RxJS a Peer Dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ clone-knora-stack:
 .PHONY: npm-install
 npm-install: ## runs 'npm install'
 	@npm install
+	@npm run peer-deps
 
 .PHONY: knora-stack
 knora-stack: ## runs the knora-stack

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ unit-tests: ## runs the unit tests
 e2e-tests: ## runs the e2e tests
 	sudo npm install yalc -g
 	npm run yalc-publish
-	cd test-framework && yalc remove --all && yalc add @knora/api && npm install && npm run webdriver-update && npm run e2e && npm run build && docker build .
+	cd test-framework && yalc remove --all && yalc add @knora/api && npm install && npm run webdriver-update && npm run e2e && npm run build-app && docker build .
 
 .PHONY: build
 build: ## builds the lib

--- a/README.md
+++ b/README.md
@@ -82,11 +82,12 @@ Any subsequent call after a successful login will be performed using the session
 
 This package provides the following short-hand scripts:
 
-1. `npm run test`: Runs the project's tests defined in `./karma.conf.js`. The coverage data is saved into the `./coverage/` folder.
-2. `npm run build`: Builds the whole project without testing and puts the files into the `./build/` folder.
-3. `npm run yalc-publish`: Executes 2 and publishes the package to the yalc app store.
-4. `npm run npm-pack`: Executes 1, 2 and packs the `./build/` folder into an NPM tgz package. The package is moved into a `./dist/` folder.
-5. `npm run npm-publish`: Executes 4 and publishes the package to the NPM store (runs in dry-run mode).
+1. `npm run peer-deps`: Installs the project's peer dependencies. Peer dependencies are not installed with `npm install`, but have to be met before building or running the tests. 
+2. `npm run test`: Runs the project's tests defined in `./karma.conf.js`. The coverage data is saved into the `./coverage/` folder.
+3. `npm run build`: Builds the whole project without testing and puts the files into the `./build/` folder.
+4. `npm run yalc-publish`: Executes 2 and publishes the package to the yalc app store.
+5. `npm run npm-pack`: Executes 1, 2 and packs the `./build/` folder into an NPM tgz package. The package is moved into a `./dist/` folder.
+6. `npm run npm-publish`: Executes 4 and publishes the package to the NPM store (runs in dry-run mode).
 
 > Note: You need to install `yalc` globally by `npm install yalc -g` to use script number 3. In order to publish a package to NPM, you need to be logged in to NPM and you have to update the version in the `package.json`.
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ see <https://docs.knora.org> -> Internals -> Development -> Generating Client Te
 3. `npm run expand-jsonld-test-data`: creates versions with expanded prefixes for Knora API v2 JSON-LD test data. 
 see <https://docs.knora.org> -> internals -> development -> generating client apis (use it without `mock=true`).
 
+# Dependencies and Peer Dependencies
+
+This library depends on `RxJS`, `jsonld`, and `json2typescript`. `jsonld` and `json2typescript` are only used internally and listed as dependencies.
+
+`RxJS` is listed as a peer dependency and **not** installed with `nmp install`. It can be installed with `npm run peer-deps`.
+`RxJS`'s `Observable` is used in this library's public API 
+and has to be compatible with whatever version of `RxJS` is used in the productive environment, e.g. an Angular application.
+This library works with `RxJS` as of version 6. See `rxjs.md` for details. 
+
 # Publish a new version to NPM
 
 Run `npm run npm-publish` as described above. The command runs `npm publish` in dry-run mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2967,14 +2967,6 @@
         "inherits": "^2.0.1"
       }
     },
-    "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
@@ -3389,7 +3381,8 @@
     "tslib": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.0.tgz",
-      "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg=="
+      "integrity": "sha512-BmndXUtiTn/VDDrJzQE7Mm22Ix3PxgLltW9bSNLoeCY31gnG2OPx0QqJnuc9oMIKioYrz487i6K9o4Pdn0j+Kg==",
+      "dev": true
     },
     "tslint": {
       "version": "5.20.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
   "dependencies": {
     "@types/jsonld": "^1.5.0",
     "json2typescript": "1.4.1",
-    "jsonld": "^1.8.0",
-    "rxjs": "~6.4.0"
+    "jsonld": "^1.8.0"
+  },
+  "peerDependencies": {
+    "rxjs": "~6.5.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "jsonld": "^1.8.0"
   },
   "peerDependencies": {
-    "rxjs": "^6.5.5"
+    "rxjs": "6.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "jsonld": "^1.8.0"
   },
   "peerDependencies": {
-    "rxjs": "~6.5.5"
+    "rxjs": "^6.5.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "yalc-publish": "npm run build && yalc publish build/ --push",
     "npm-pack": "npm run test && npm run build && npm pack build/ && mkdir -p dist/ && cp *.tgz dist/ && rm *.tgz",
     "npm-publish": "npm run npm-pack && npm publish build/ --dry-run",
-    "builddocs": "typedoc --out docs --readme none --name '@knora/api API Documentation' --exclude \"**/*.spec.*\" src/*.ts"
+    "builddocs": "typedoc --out docs --readme none --name '@knora/api API Documentation' --exclude \"**/*.spec.*\" src/*.ts",
+    "peer-deps": "npm i rxjs --no-save"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "npm-pack": "npm run test && npm run build && npm pack build/ && mkdir -p dist/ && cp *.tgz dist/ && rm *.tgz",
     "npm-publish": "npm run npm-pack && npm publish build/ --dry-run",
     "builddocs": "typedoc --out docs --readme none --name '@knora/api API Documentation' --exclude \"**/*.spec.*\" src/*.ts",
-    "peer-deps": "npm i rxjs --no-save"
+    "peer-deps": "npm i rxjs@6.x --no-save"
   },
   "repository": {
     "type": "git",

--- a/rxjs.md
+++ b/rxjs.md
@@ -1,0 +1,29 @@
+# Use of RxJS
+
+## Introduction
+
+This library heavily depends on `RxJS`.
+This document lists all uses of `RxJS` to facilitate upgrading to 
+[future versions](https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md) 
+of `RxJS` which might have breaking changes.
+
+## Imports from RxJS
+
+- from `rxjs`:    
+   - `AsyncSubject`
+   - `forkJoin`
+   - `throwError`
+   - `of`
+   - `Observable`
+
+- from `rxjs/ajax`:
+    - `ajax`
+    - `AjaxError`
+    - `AjaxResponse`
+    
+- from `rxjs/operators`:
+    - `catchError`
+    - `map`
+    - `mergeMap`
+    - `take`
+

--- a/test-framework/Dockerfile
+++ b/test-framework/Dockerfile
@@ -26,7 +26,7 @@ RUN npm install
 
 ## Build the angular app in production mode and store the artifacts in dist folder
 ## should be: $(npm bin)/ng build --prod --env=prod --build-optimizer
-RUN npm run build
+RUN npm run build-app
 
 ### STAGE 2: Setup ###
 

--- a/test-framework/package.json
+++ b/test-framework/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod=true --buildOptimizer=true --progress=true",
+    "build-app": "ng build --prod=true --buildOptimizer=true --progress=true",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e --prod=true --protractor-config=./e2e/protractor.conf.js --webdriver-update=false",

--- a/test-framework/package.json
+++ b/test-framework/package.json
@@ -8,7 +8,8 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e --prod=true --protractor-config=./e2e/protractor.conf.js --webdriver-update=false",
-    "webdriver-update": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.37"
+    "webdriver-update": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.37",
+    "yalc-add": "yalc remove --all && yalc add @knora/api"
   },
   "private": true,
   "dependencies": {
@@ -20,11 +21,11 @@
     "@angular/platform-browser": "~7.2.0",
     "@angular/platform-browser-dynamic": "~7.2.0",
     "@angular/router": "~7.2.0",
-    "@knora/api": "file:.yalc/@knora/api",
     "core-js": "^2.5.4",
     "rxjs": "^6.4.0",
     "tslib": "^1.9.0",
-    "zone.js": "~0.8.26"
+    "zone.js": "~0.8.26",
+    "@knora/api": "file:.yalc/@knora/api"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.12.0",

--- a/test-framework/src/app/app.component.ts
+++ b/test-framework/src/app/app.component.ts
@@ -27,6 +27,8 @@ import {
   DeleteResource
 } from '@knora/api';
 
+import {map} from 'rxjs/operators'
+
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',

--- a/test-framework/src/app/app.component.ts
+++ b/test-framework/src/app/app.component.ts
@@ -126,8 +126,7 @@ export class AppComponent implements OnInit {
 
     this.knoraApiConnection.v2.res.getResource(iri).pipe(
         map(
-            (res) => {
-                console.log('test');
+            (res) => { // make sure RxJS versions (Observable) are compatible
                 return res;
             })
     ).subscribe(

--- a/test-framework/src/app/app.component.ts
+++ b/test-framework/src/app/app.component.ts
@@ -26,7 +26,7 @@ import {
 import {UpdateResourceMetadata} from '../../.yalc/@knora/api/src/models/v2/resources/update/update-resource-metadata';
 import {UpdateResourceMetadataResponse} from '../../.yalc/@knora/api/src/models/v2/resources/update/update-resource-metadata-response';
 import {DeleteResource} from '../../.yalc/@knora/api/src/models/v2/resources/delete/delete-resource';
-
+import {map} from 'rxjs/operators'
 
 @Component({
   selector: 'app-root',
@@ -123,7 +123,13 @@ export class AppComponent implements OnInit {
 
   getResource(iri: string) {
 
-    this.knoraApiConnection.v2.res.getResource(iri).subscribe(
+    this.knoraApiConnection.v2.res.getResource(iri).pipe(
+        map(
+            (res) => {
+                console.log('test');
+                return res;
+            })
+    ).subscribe(
         (res: ReadResource) => {
           console.log(res);
           this.resource = res;

--- a/test-framework/yalc.lock
+++ b/test-framework/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "@knora/api": {
-      "signature": "671c36653a5277d73b20ef7ee9bf56bb",
+      "signature": "3b4cdff86c03f0d26f08dd98e101651a",
       "file": true
     }
   }

--- a/test-framework/yalc.lock
+++ b/test-framework/yalc.lock
@@ -2,7 +2,7 @@
   "version": "v1",
   "packages": {
     "@knora/api": {
-      "signature": "c0d20c8e29a3ed4f0e13ee6f5e8ffa93",
+      "signature": "671c36653a5277d73b20ef7ee9bf56bb",
       "file": true
     }
   }


### PR DESCRIPTION
This PR makes RxJS a peer dependency of the lib. This is necessary because the lib exposes RxJS's `Observable` in its public API. The lib is used by an Angular application that also requires RxJS. If the two versions are different, then the two Observables are treated as if they were different classes, resulting in a compile error like

> Types of property 'source' are incompatible.
        Type 'import(".../knora-api-js-lib/test-framework/node_modules/@knora/api/node_modules/rxjs/internal/Observable").Observable<any>' is not assignable to type 'import(".../test-framework/node_modules/rxjs/internal/Observable").Observable<any>'.

I think this is exactly what peer dependencies attempt to solve:

> But now what if JacksModule exposes its dependency on JillsModule in some way. It accepts an instance of JillsClass for example... What happens when we create a new JillsClass using version 2.0 of the library and pass it along to jacksFunction? All hell will break loose! Simple things like jillsObject instanceof JillsClass will suddenly return false because jillsObject is actually an instance of another JillsClass, the 2.0 version.

https://stackoverflow.com/questions/26737819/why-use-peer-dependencies-in-npm-for-plugins#answer-34645112
