### PR TITLE
Integrate mockresource

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ generate-test-data: ## downloads generated test data from Knora-API
 	@rm -rf $(CURRENT_DIR)/.tmp/typescript
 	mkdir -p $(CURRENT_DIR)/.tmp/typescript
 	curl -o $(CURRENT_DIR)/.tmp/ts.zip http://localhost:3333/clientapitest
-	sleep 5
+	sleep 30
 	unzip $(CURRENT_DIR)/.tmp/ts.zip -d $(CURRENT_DIR)/.tmp/typescript
 
 .PHONY: integrate-test-data

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ generate-test-data: ## downloads generated test data from Knora-API
 	@rm -rf $(CURRENT_DIR)/.tmp/typescript
 	mkdir -p $(CURRENT_DIR)/.tmp/typescript
 	curl -o $(CURRENT_DIR)/.tmp/ts.zip http://localhost:3333/clientapitest
+	sleep 5
 	unzip $(CURRENT_DIR)/.tmp/ts.zip -d $(CURRENT_DIR)/.tmp/typescript
 
 .PHONY: integrate-test-data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/api",
-  "version": "0.1.1",
+  "version": "1.0.1-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/api",
-  "version": "1.0.1-rc.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/api",
-  "version": "0.2.0",
+  "version": "1.0.0-rc.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/api",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/api",
-  "version": "1.0.1-rc.0",
+  "version": "1.0.0",
   "description": "JavaScript library that handles API requests to Knora",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/api",
-  "version": "0.2.0",
+  "version": "1.0.0-rc.0",
   "description": "JavaScript library that handles API requests to Knora",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/api",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "JavaScript library that handles API requests to Knora",
   "main": "index.js",
   "files": [
@@ -16,7 +16,7 @@
     "integrate-v2-test-data": "node scripts/integrate-files-v2.js",
     "expand-jsonld-test-data": "node scripts/expand-jsonld-test-data-files.js",
     "test": "karma start karma.conf.js",
-    "build": "tsc && mkdir -p build/ && cp CHANGELOG.md build/ && cp LICENSE build/ && cp README.md build/ && cp package.json build/",
+    "build": "rm -rf build/* && tsc && mkdir -p build/ && cp CHANGELOG.md build/ && cp LICENSE build/ && cp README.md build/ && cp package.json build/",
     "yalc-publish": "npm run build && yalc publish build/ --push",
     "npm-pack": "npm run test && npm run build && npm pack build/ && mkdir -p dist/ && cp *.tgz dist/ && rm *.tgz",
     "npm-publish": "npm run npm-pack && npm publish build/ --dry-run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/api",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "description": "JavaScript library that handles API requests to Knora",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knora/api",
-  "version": "1.0.0",
+  "version": "1.0.1-rc.0",
   "description": "JavaScript library that handles API requests to Knora",
   "main": "index.js",
   "files": [

--- a/test-framework/src/app/app.component.ts
+++ b/test-framework/src/app/app.component.ts
@@ -24,7 +24,8 @@ import {
   WriteValueResponse,
   UpdateResourceMetadata,
   UpdateResourceMetadataResponse,
-  DeleteResource
+  DeleteResource,
+  DeleteResourceResponse
 } from '@knora/api';
 
 import {map} from 'rxjs/operators'
@@ -197,7 +198,7 @@ export class AppComponent implements OnInit {
     deleteResource.type = this.resource.type;
 
     this.knoraApiConnection.v2.res.deleteResource(deleteResource).subscribe(
-        (res: DeleteValueResponse) => {
+        (res: DeleteResourceResponse) => {
           this.resourceStatus = 'OK';
         }
     );

--- a/test/data/api/v2/mock-resource.ts
+++ b/test/data/api/v2/mock-resource.ts
@@ -1,0 +1,54 @@
+import { JsonConvert, OperationMode, ValueCheckingMode } from "json2typescript";
+import { PropertyMatchingRule } from "json2typescript/src/json2typescript/json-convert-enums";
+import { Observable, of } from "rxjs";
+import { V2Endpoint } from "../../../../src/api/v2/v2-endpoint";
+import { ListNodeV2Cache } from "../../../../src/cache/ListNodeV2Cache";
+import { OntologyCache } from "../../../../src/cache/OntologyCache";
+import { KnoraApiConfig } from "../../../../src/knora-api-config";
+import { ReadResource } from "../../../../src/models/v2/resources/read/read-resource";
+import { ResourcesConversionUtil } from "../../../../src/models/v2/resources/ResourcesConversionUtil";
+import testthing from "../v2/resources/testding-expanded.json";
+import { MockList } from "./mockList";
+import { MockOntology } from "./mockOntology";
+
+export namespace MockResource {
+
+    const jsonConvert: JsonConvert = new JsonConvert(
+        OperationMode.ENABLE,
+        ValueCheckingMode.DISALLOW_NULL,
+        false,
+        PropertyMatchingRule.CASE_STRICT
+    );
+
+    export const getTestthing = (): Observable<ReadResource[]> => {
+
+        const config = new KnoraApiConfig("http", "");
+
+        const v2Endpoint = new V2Endpoint(config, "");
+
+        const ontoCache = new OntologyCache(config, v2Endpoint);
+
+        const listNodeCache = new ListNodeV2Cache(v2Endpoint);
+
+        // replace actual cache methods with class to exiting mock factories
+
+        // use ontology mock factory
+        ontoCache.getResourceClassDefinition = (resClassIri: string) => {
+
+            const mock = MockOntology.mockIResourceClassAndPropertyDefinitions(resClassIri);
+
+            return of(mock);
+        };
+
+        // use list node mock factory
+        listNodeCache.getNode = (listNodeIri: string) => {
+
+            return MockList.mockCompletedAsyncSubject(listNodeIri);
+
+        };
+
+        return ResourcesConversionUtil.createReadResourceSequence(testthing, ontoCache, listNodeCache, jsonConvert);
+
+    };
+
+}


### PR DESCRIPTION
This PR prepares the automated publication process of the dev package.

The lib contains mock factories to generate test data that are not exported for the productive build. By adding those files to the build of the dev packag, these can be used by knora-ui-ng-lib.

In a subsequent PR, I will try to add a script to automate the build of the dev package.