### PR TITLE
Use tagged Knora version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ include vars.mk
 # Clones the knora-api git repository
 .PHONY: clone-knora-stack
 clone-knora-stack:
-	@git clone --single-branch --depth 1 https://github.com/dasch-swiss/knora-api.git $(CURRENT_DIR)/.tmp/knora-stack
+	@git clone --branch v13.0.0-PR1 --single-branch --depth 1 https://github.com/dasch-swiss/knora-api.git $(CURRENT_DIR)/.tmp/knora-stack
 
 #################################
 # Integration test targets
@@ -39,9 +39,9 @@ knora-stack: ## runs the knora-stack
 generate-test-data: ## downloads generated test data from Knora-API
 	@rm -rf $(CURRENT_DIR)/.tmp/typescript
 	mkdir -p $(CURRENT_DIR)/.tmp/typescript
+	sleep 240
+	curl --fail --retry 5 --retry-connrefused -w http_code -o $(CURRENT_DIR)/.tmp/ts.zip http://localhost:3333/clientapitest
 	sleep 120
-	curl --fail -o $(CURRENT_DIR)/.tmp/ts.zip http://localhost:3333/clientapitest
-	sleep 45
 	unzip $(CURRENT_DIR)/.tmp/ts.zip -d $(CURRENT_DIR)/.tmp/typescript
 
 .PHONY: integrate-test-data


### PR DESCRIPTION
- use a tagged version of Knora in tests on github-ci
- make curl retry after failed requests