### PR TITLE
ontology IRI: ignore port if not running on localhost

### DIFF
--- a/src/models/v2/ontologies/OntologyConversionUtil.spec.ts
+++ b/src/models/v2/ontologies/OntologyConversionUtil.spec.ts
@@ -11,64 +11,74 @@ describe("OntologyConversionUtil", () => {
         jasmine.Ajax.uninstall();
     });
 
-    describe("Method getOntologyIriFromEntityIri", () => {
-        const localConfig = new KnoraApiConfig("http", "0.0.0.0", 3333);
-        const remoteConfig = new KnoraApiConfig("https", "test.example.com", 3333);
+    describe("Method getOntologyIriFromEntityIri with local setup", () => {
+        const config = new KnoraApiConfig("http", "0.0.0.0", 3333);
 
         it("should get the ontology IRI from a knora-api entity", () => {
-            const localOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+            const ontologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
                 "http://api.knora.org/ontology/knora-api/v2#Resource",
-                localConfig
+                config
             );
 
-            expect(localOntologyIri[0]).toEqual(
+            expect(ontologyIri[0]).toEqual(
                 "http://api.knora.org/ontology/knora-api/v2"
             );
+        });
 
-            const remoteOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
-                "http://api.knora.org/ontology/knora-api/v2#Resource",
-                remoteConfig
+        it("should get the ontology IRI from a project entity", () => {
+            const ontologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+                "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing",
+                config
             );
 
-            expect(remoteOntologyIri[0]).toEqual(
+            expect(ontologyIri[0]).toEqual(
+                "http://0.0.0.0:3333/ontology/0001/anything/v2"
+            );
+        });
+
+        it("should ignore an external entity", () => {
+            const ontologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+                "http://www.w3.org/2000/01/rdf-schema#label",
+                config
+            );
+
+            expect(ontologyIri.length).toEqual(0);
+        });
+
+    });
+
+    describe("Method getOntologyIriFromEntityIri with remote setup", () => {
+        const config = new KnoraApiConfig("https", "test.example.com", 3333);
+
+        it("should get the ontology IRI from a knora-api entity", () => {
+            const ontologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+                "http://api.knora.org/ontology/knora-api/v2#Resource",
+                config
+            );
+
+            expect(ontologyIri[0]).toEqual(
               "http://api.knora.org/ontology/knora-api/v2"
             );
         });
 
         it("should get the ontology IRI from a project entity", () => {
-            const localOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
-                "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing",
-                localConfig
-            );
-
-            expect(localOntologyIri[0]).toEqual(
-                "http://0.0.0.0:3333/ontology/0001/anything/v2"
-            );
-
-            const remoteOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+            const ontologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
                 "http://test.example.com/ontology/0001/anything/v2#Thing",
-                remoteConfig
+                config
             );
 
-            expect(remoteOntologyIri[0]).toEqual(
+            expect(ontologyIri[0]).toEqual(
                 "http://test.example.com/ontology/0001/anything/v2"
             );
         });
 
         it("should ignore an external entity", () => {
-            const localOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+            const ontologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
                 "http://www.w3.org/2000/01/rdf-schema#label",
-                localConfig
+                config
             );
 
-            expect(localOntologyIri.length).toEqual(0);
-
-            const remoteOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
-                "http://www.w3.org/2000/01/rdf-schema#label",
-                remoteConfig
-            );
-
-            expect(remoteOntologyIri.length).toEqual(0);
+            expect(ontologyIri.length).toEqual(0);
         });
 
     });

--- a/src/models/v2/ontologies/OntologyConversionUtil.spec.ts
+++ b/src/models/v2/ontologies/OntologyConversionUtil.spec.ts
@@ -12,28 +12,63 @@ describe("OntologyConversionUtil", () => {
     });
 
     describe("Method getOntologyIriFromEntityIri", () => {
-
-        const config = new KnoraApiConfig("http", "0.0.0.0", 3333);
+        const localConfig = new KnoraApiConfig("http", "0.0.0.0", 3333);
+        const remoteConfig = new KnoraApiConfig("https", "test.example.com", 3333);
 
         it("should get the ontology IRI from a knora-api entity", () => {
-            const ontologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri("http://api.knora.org/ontology/knora-api/v2#Resource", config);
+            const localOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+                "http://api.knora.org/ontology/knora-api/v2#Resource",
+                localConfig
+            );
 
-            expect(ontologyIri[0]).toEqual("http://api.knora.org/ontology/knora-api/v2");
+            expect(localOntologyIri[0]).toEqual(
+                "http://api.knora.org/ontology/knora-api/v2"
+            );
 
+            const remoteOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+                "http://api.knora.org/ontology/knora-api/v2#Resource",
+                remoteConfig
+            );
+
+            expect(remoteOntologyIri[0]).toEqual(
+              "http://api.knora.org/ontology/knora-api/v2"
+            );
         });
 
         it("should get the ontology IRI from a project entity", () => {
-            const ontologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri("http://0.0.0.0:3333/ontology/0001/anything/v2#Thing", config);
+            const localOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+                "http://0.0.0.0:3333/ontology/0001/anything/v2#Thing",
+                localConfig
+            );
 
-            expect(ontologyIri[0]).toEqual("http://0.0.0.0:3333/ontology/0001/anything/v2");
+            expect(localOntologyIri[0]).toEqual(
+                "http://0.0.0.0:3333/ontology/0001/anything/v2"
+            );
 
+            const remoteOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+                "http://test.example.com/ontology/0001/anything/v2#Thing",
+                remoteConfig
+            );
+
+            expect(remoteOntologyIri[0]).toEqual(
+                "http://test.example.com/ontology/0001/anything/v2"
+            );
         });
 
         it("should ignore an external entity", () => {
-            const ontologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri("http://www.w3.org/2000/01/rdf-schema#label", config);
+            const localOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+                "http://www.w3.org/2000/01/rdf-schema#label",
+                localConfig
+            );
 
-            expect(ontologyIri.length).toEqual(0);
+            expect(localOntologyIri.length).toEqual(0);
 
+            const remoteOntologyIri = OntologyConversionUtil.getOntologyIriFromEntityIri(
+                "http://www.w3.org/2000/01/rdf-schema#label",
+                remoteConfig
+            );
+
+            expect(remoteOntologyIri.length).toEqual(0);
         });
 
     });

--- a/src/models/v2/ontologies/OntologyConversionUtil.ts
+++ b/src/models/v2/ontologies/OntologyConversionUtil.ts
@@ -23,8 +23,11 @@ export namespace OntologyConversionUtil {
 
         const ontologyIri: string[] = [];
 
+        // set `http` regardless of  knoraApiConfig.apiProtocol
+        // include port only when running locally
         let projectEntityBase = "http://" + knoraApiConfig.apiHost;
-        if (knoraApiConfig.apiPort !== null) {
+        if (knoraApiConfig.apiPort !== null &&
+             (knoraApiConfig.apiHost === "localhost" || knoraApiConfig.apiHost === "0.0.0.0")) {
             projectEntityBase = projectEntityBase + ":" + knoraApiConfig.apiPort;
         }
         projectEntityBase = projectEntityBase + "/ontology/";


### PR DESCRIPTION
follow knora's recipe for forging an IRI: https://github.com/dasch-swiss/knora-api/blob/0127dcae27e46bc3a4c9947282c30038c0a25d20/webapi/src/main/scala/org/knora/webapi/Settings.scala#L54