### PR TITLE
Preparation for next pre-release 1.0.0-rc.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
         run: npm run build
       - if: "github.event.release.prerelease"
         name: Publish prerelease to npm
-        run: npm publish --tag rc build/ --access public^
+        run: npm publish --tag rc build/ --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_DASCHBOT}}
       - if: "!github.event.release.prerelease"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,12 +75,12 @@ jobs:
         run: npm run build
       - if: "github.event.release.prerelease"
         name: Publish prerelease to npm
-        run: npm publish --tag rc build/ --access public --dry-run
+        run: npm publish --tag rc build/ --access public^
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_DASCHBOT}}
       - if: "!github.event.release.prerelease"
         name: Publish release to npm
-        run: npm publish build/ --access public --dry-run
+        run: npm publish build/ --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_DASCHBOT}}
       - uses: lakto/gren-action@v1.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DSP-JS-LIB &mdash; A library to easily connect to Knora/DSP API
 
-[![npm version](https://badge.fury.io/js/%40dasch-swiss%2Fdsp-js.svg)](https://badge.fury.io/js/%40dasch-swiss%2Fdsp-js)
+[![npm version](https://badge.fury.io/js/%40dasch-swiss%2Fdsp-js.svg)](https://www.npmjs.com/package/@dasch-swiss/dsp-js)
 [![CI](https://github.com/dasch-swiss/knora-api-js-lib/workflows/CI/badge.svg)](https://github.com/dasch-swiss/knora-api-js-lib/actions?query=workflow%3ACI)
 [![npm downloads](https://img.shields.io/npm/dt/@dasch-swiss/dsp-js.svg?style=flat)](https://www.npmjs.com/package/@dasch-swiss/dsp-js)
 [![minzipped size](https://img.shields.io/bundlephobia/minzip/@dasch-swiss/dsp-js.svg?style=flat)](https://www.npmjs.com/package/@dasch-swiss/dsp-js)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dasch-swiss/dsp-js",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dasch-swiss/dsp-js",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "description": "JavaScript library that handles API requests to Knora",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
I created two "test" releases on Github to see if the expected publish process will run. I have already deleted these releases. But you can still have a look at the workflow: https://github.com/dasch-swiss/knora-api-js-lib/runs/780497476?check_suite_focus=true

In this PR I removed the `--dry-run` flag from `npm publish` and updated the version number to next prerelease `v1.0.0-rc.3`. When this PR is merged, we can create new release on Github and the CI workflow will publish a new package to npm.